### PR TITLE
Make browserify-friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   },
   "main": "build/hierarchy",
   "jsnext:main": "index",
+  "browser": "index.js",
+  "browserify": {
+    "transform": ["babelify"]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/d3/d3-hierarchy.git"
@@ -32,5 +36,8 @@
     "faucet": "0.0",
     "tape": "4",
     "uglify-js": "2"
+  },
+  "dependencies": {
+    "babelify": "^6.1.2"
   }
 }


### PR DESCRIPTION
Adds the [babelify](https://github.com/babel/babelify) transform for ES6 modules support, and adds `"browser": "index.js"` for browserify to target instead of `"build/hierarchy.js"`.

Alternatively, publishing the package on npm will also to the trick: the above is only required since the build directory is missing from Git and won't be installed when doing `npm install d3/d3-hierarchy` :)

Thanks!