### PR TITLE
Improve asymptotic performance of binary treemap

### DIFF
--- a/src/treemap/binary.js
+++ b/src/treemap/binary.js
@@ -1,9 +1,14 @@
 export default function(parent, x0, y0, x1, y1) {
   var nodes = parent.children;
-  partition(nodes, 0, nodes.length, parent.value, x0, y0, x1, y1);
+  var sums = [0];
+  for (var i = 0; i < nodes.length; i++) {
+    sums[i+1] = sums[i] + nodes[i].value;
+  }
+  partition(nodes, sums, 0, nodes.length, parent.value, x0, y0, x1, y1);
 }
 
-function partition(nodes, i, j, value, x0, y0, x1, y1) {
+
+function partition(nodes, sums, i, j, value, x0, y0, x1, y1) {
   if (i >= j - 1) {
     nodes = nodes[i];
     nodes.x0 = x0, nodes.y0 = y0;
@@ -11,17 +16,29 @@ function partition(nodes, i, j, value, x0, y0, x1, y1) {
     return;
   }
 
-  var k = i, valueHalf = value / 2, valueLeft = 0;
-  do valueLeft += nodes[k].value; while (++k < j - 1 && valueLeft < valueHalf);
+  var offset = sums[i];
+  var goal = (value / 2) + offset;
+
+  var k = i+1, ub = j-1, mid;
+  while(k < ub) {
+    mid = (k + ub) >>> 1;
+    if (sums[mid] < goal) {
+      k = mid+1;
+    } else {
+      ub = mid;
+    }
+  }
+
+  var valueLeft = sums[k] - offset;
   var valueRight = value - valueLeft;
 
   if ((y1 - y0) > (x1 - x0)) {
     var yk = (y0 * valueRight + y1 * valueLeft) / value;
-    partition(nodes, i, k, valueLeft, x0, y0, x1, yk);
-    partition(nodes, k, j, valueRight, x0, yk, x1, y1);
+    partition(nodes, sums, i, k, valueLeft, x0, y0, x1, yk);
+    partition(nodes, sums, k, j, valueRight, x0, yk, x1, y1);
   } else {
     var xk = (x0 * valueRight + x1 * valueLeft) / value;
-    partition(nodes, i, k, valueLeft, x0, y0, xk, y1);
-    partition(nodes, k, j, valueRight, xk, y0, x1, y1);
+    partition(nodes, sums, i, k, valueLeft, x0, y0, xk, y1);
+    partition(nodes, sums, k, j, valueRight, xk, y0, x1, y1);
   }
 }


### PR DESCRIPTION
The current algorithm for computing partitions in a binary treemap performs a lot of redundant prefix sums and therefore has sub-optimal asymptotic performance.

In the worst-case, where each call to `partition` results in the right split having exactly one child node (this happens when children have values in increasing powers of two), the runtime is **O(*n*<sup>2</sup>)**. On the other hand, the best-case performance is  **O(*n*)**, when the values are in decreasing powers of two.

The asymptotic performance can be improved by pre-computing the prefix sums of all the children and performing a binary search at each call to `partition` to locate the split point. With this, the best-case performance is **O(*n*)** (for even splits when all children have the same value) and the worst-case performance is **O(*n* log *n*)** (for unbalanced splits).

Here are some results of a [benchmark](https://gist.github.com/rohanpadhye/51cc442ac8d9508dbdd729e1f8351ea0) that measures execution times for 1,000 iterations of three trees with 1,000 children on my machine (Macbook Pro with Node v5.3.0). 

Before:
```
Even splits     : 46.061ms
Unbalanced-left : 1466.794ms
Unbalanced-right: 43.297ms
```

After:
```
Even splits     : 53.034ms
Unbalanced-left : 74.412ms
Unbalanced-right: 60.188ms
```

There is of course some overhead for creating the prefix sum array, but the performance is consistent across different value distributions. In particular, the worst-case has improved by almost 20X, while the best-case has degraded by less than 25%.

The fix currently uses an inline implementation of binary search, but [Lines 22-30] (https://github.com/rohanpadhye/d3-hierarchy/blob/0a986f83489dfdde2012ff4aeb0da2bb3b8dbc67/src/treemap/binary.js#L22-L30) can be replaced with the following if `d3-array` is included as a dependency:
```
var k = bisectLeft(sums, goal, i+1, j-1);
```
