### PR TITLE
Generate treemap on child node of hierarchy

### DIFF
--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -8,7 +8,7 @@ export default function() {
       round = false,
       dx = 1,
       dy = 1,
-      paddingStack = [0],
+      paddingStack = [],
       paddingInner = constantZero,
       paddingTop = constantZero,
       paddingRight = constantZero,
@@ -20,8 +20,9 @@ export default function() {
     root.y0 = 0;
     root.x1 = dx;
     root.y1 = dy;
+    paddingStack[root.depth] = 0;
     root.eachBefore(positionNode);
-    paddingStack = [0];
+    paddingStack = [];
     if (round) root.eachBefore(roundNode);
     return root;
   }

--- a/test/treemap/index-test.js
+++ b/test/treemap/index-test.js
@@ -1,7 +1,8 @@
 var tape = require("tape"),
     d3_hierarchy = require("../../"),
     round = require("./round"),
-    simple = require("../data/simple2");
+    simple = require("../data/simple2"),
+    nested = require("../data/simple");
 
 tape("treemap() has the expected defaults", function(test) {
   var treemap = d3_hierarchy.treemap();
@@ -178,6 +179,20 @@ tape("treemap(data) observes the specified sibling order", function(test) {
   test.deepEqual(root.descendants().map(function(d) { return d.value; }), [24, 1, 2, 2, 3, 4, 6, 6]);
   test.end();
 });
+
+tape("treemap(data) accepts non-root node", function(test) {
+  var treemap = d3_hierarchy.treemap(),
+      root = d3_hierarchy.hierarchy(nested).sum(defaultValue).sort(ascendingValue),
+      child = treemap(root.children[1]),
+      nodes = child.descendants().map(round);
+  test.deepEqual(nodes, [
+    { x0: 0.00, y0: 0.00, x1: 1.00, y1: 1.00 },
+    { x0: 0.00, y0: 0.00, x1: 0.56, y1: 0.40 },
+    { x0: 0.00, y0: 0.40, x1: 0.56, y1: 1.00 },
+    { x0: 0.56, y0: 0.00, x1: 1.00, y1: 1.00 }
+  ]);
+  test.end();
+})
 
 function defaultValue(d) {
   return d.value;


### PR DESCRIPTION
This PR enables treemap(data) to accept a child node of a hierarchy by removing the assumption that the starting depth is 0.

Encountered during the creation of a mostly frivolous bar chart of treemaps example, but perhaps there are other use cases where a treemap is nested inside something else that also wants to take advantage of d3.hierarchy features.

Test included. Thanks for D3.