### PR TITLE
Added stratify.props method and tests.

### DIFF
--- a/src/stratify.js
+++ b/src/stratify.js
@@ -13,9 +13,14 @@ function defaultParentId(d) {
   return d.parentId;
 }
 
+function defaultProps(d) {
+  return d;
+}
+
 export default function() {
   var id = defaultId,
-      parentId = defaultParentId;
+      parentId = defaultParentId,
+      props = defaultProps;
 
   function stratify(data) {
     var d,
@@ -30,8 +35,8 @@ export default function() {
         nodeByKey = {};
 
     for (i = 0; i < n; ++i) {
-      d = data[i], node = nodes[i] = new Node(d);
-      if ((nodeId = id(d, i, data)) != null && (nodeId += "")) {
+      d = props(data[i]), node = nodes[i] = new Node(d);
+      if ((nodeId = id(data[i], i, data)) != null && (nodeId += "")) {
         nodeKey = keyPrefix + (node.id = nodeId);
         nodeByKey[nodeKey] = nodeKey in nodeByKey ? ambiguous : node;
       }
@@ -67,6 +72,10 @@ export default function() {
 
   stratify.parentId = function(x) {
     return arguments.length ? (parentId = required(x), stratify) : parentId;
+  };
+
+  stratify.props = function(x) {
+    return arguments.length ? (props = required(x), stratify) : props;
   };
 
   return stratify;

--- a/test/stratify-test.js
+++ b/test/stratify-test.js
@@ -406,6 +406,54 @@ tape("stratify.parentId(id) tests that id is a function", function(test) {
   test.end();
 });
 
+tape("stratify.props(props) observes the specified props function", function(test) {
+  var foo = function(d) { return d.foo; },
+    s = d3_hierarchy.stratify().props(foo),
+    root = s([
+      {foo: "zz", id: "a"},
+      {foo: "zz", id: "aa", parentId: "a"},
+      {foo: "zz", id: "ab", parentId: "a"},
+      {foo: "zz", id: "aaa", parentId: "aa"}
+    ]);
+  test.equal(s.id(), foo);
+  test.deepEqual(noparent(root), {
+    id: "a",
+    depth: 0,
+    height: 2,
+    data: {foo: "zz"},
+    children: [
+      {
+        id: "aa",
+        depth: 1,
+        height: 1,
+        data: {foo: "zz"},
+        children: [
+          {
+            id: "aaa",
+            depth: 2,
+            height: 0,
+            data: {foo: "zz"}
+          }
+        ]
+      },
+      {
+        id: "ab",
+        depth: 1,
+        height: 0,
+        data: {foo: "ab"}
+      }
+    ]
+  });
+  test.end();
+});
+
+tape("stratify.props(props) tests that props is a function", function(test) {
+  var s = d3_hierarchy.stratify();
+  test.throws(function() { s.id(42); });
+  test.throws(function() { s.id(null); });
+  test.end();
+});
+
 function noparent(node) {
   var copy = {};
   for (var k in node) {

--- a/test/stratify-test.js
+++ b/test/stratify-test.js
@@ -407,7 +407,7 @@ tape("stratify.parentId(id) tests that id is a function", function(test) {
 });
 
 tape("stratify.props(props) observes the specified props function", function(test) {
-  var foo = function(d) { return d.foo; },
+  var foo = function(d) { return { foo: d.foo }; },
     s = d3_hierarchy.stratify().props(foo),
     root = s([
       {foo: "zz", id: "a"},
@@ -415,7 +415,7 @@ tape("stratify.props(props) observes the specified props function", function(tes
       {foo: "zz", id: "ab", parentId: "a"},
       {foo: "zz", id: "aaa", parentId: "aa"}
     ]);
-  test.equal(s.id(), foo);
+  test.equal(s.props(), foo);
   test.deepEqual(noparent(root), {
     id: "a",
     depth: 0,
@@ -440,7 +440,7 @@ tape("stratify.props(props) observes the specified props function", function(tes
         id: "ab",
         depth: 1,
         height: 0,
-        data: {foo: "ab"}
+        data: {foo: "zz"}
       }
     ]
   });
@@ -449,8 +449,8 @@ tape("stratify.props(props) observes the specified props function", function(tes
 
 tape("stratify.props(props) tests that props is a function", function(test) {
   var s = d3_hierarchy.stratify();
-  test.throws(function() { s.id(42); });
-  test.throws(function() { s.id(null); });
+  test.throws(function() { s.props(42); });
+  test.throws(function() { s.props(null); });
   test.end();
 });
 


### PR DESCRIPTION
Added and tested a method on the stratify constructor that allows the user to define a schema to the nodes' `data` property.

The design pattern is similar to that of `.id()` and `.parentId()`:

```
cost s = stratify.props((d) => ({
    foo: d.foo,
    bar: d.bar
});
```

This partially solves issue #53; all tests check out.

I found it odd to have the id properties inside of data for some use cases (which is something that still needs to be addressed, as the use of `.props()` will lead to nodes having no `parentId` on nodes unless explicitly mapped).

The parentId should be on the node objects itself as opposed to the data property, but I didn't want to introduce any breaking changes with this PR. Thoughts on this are welcome.