### PR TITLE
Treemap-squarify: skip zero values to avoid breaking treemap

### DIFF
--- a/src/treemap/squarify.js
+++ b/src/treemap/squarify.js
@@ -34,6 +34,7 @@ export function squarifyRatio(ratio, parent, x0, y0, x1, y1) {
     // Keep adding nodes while the aspect ratio maintains or improves.
     for (; i1 < n; ++i1) {
       sumValue += nodeValue = nodes[i1].value;
+      if (nodeValue === 0) { continue; }
       if (nodeValue < minValue) minValue = nodeValue;
       if (nodeValue > maxValue) maxValue = nodeValue;
       beta = sumValue * sumValue * alpha;


### PR DESCRIPTION
If there are zero values in the treemap data, the treemap itself renders incorrectly when 'squarify' algorithm is used:
![diagram](https://cloud.githubusercontent.com/assets/303465/20465033/c838c324-af5c-11e6-85b6-097d65566f4d.png)
It happens because of division by 0. As a result, newRatio becomes equal to Infinity, and never changes back.

Archive with the working example of the issue: [d3-issue-example.zip](https://github.com/d3/d3-hierarchy/files/602210/d3-issue-example.zip)
