### PR TITLE
add split treemap algorithm as tile (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,11 @@ Like [d3.treemapSquarify](#treemapSquarify), except preserves the topology (node
 
 Specifies the desired aspect ratio of the generated rectangles. The *ratio* must be specified as a number greater than or equal to one. Note that the orientation of the generated rectangles (tall or wide) is not implied by the ratio; for example, a ratio of two will attempt to produce a mixture of rectangles whose *width*:*height* ratio is either 2:1 or 1:2. (However, you can approximately achieve this result by generating a square treemap at different dimensions, and then [stretching the treemap](http://bl.ocks.org/mbostock/5c50a377e76a1974248bd628befdec95) to the desired aspect ratio.) Furthermore, the specified *ratio* is merely a hint to the tiling algorithm; the rectangles are not guaranteed to have the specified aspect ratio. If not specified, the aspect ratio defaults to the golden ratio, φ = (1 + sqrt(5)) / 2, per [Kong *et al.*](http://vis.stanford.edu/papers/perception-treemaps)
 
+<a name="treemapSplit" href="#treemapSplit">#</a> d3.<b>treemapSplit</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) [<>](https://github.com/d3/d3-hierarchy/blob/master/src/treemap/split.js "Source")
+
+Recursively splits the provided *nodes* as closely as possible into two equally sized groups until it reaches groups of 0 or 1 node(s).  The split occurs horizontally if width is greater than height or vertically if height is greater.
+
+
 ### Partition
 
 [<img alt="Partition" src="https://raw.githubusercontent.com/d3/d3-hierarchy/master/img/partition.png">](http://bl.ocks.org/mbostock/2e73ec84221cb9773f4c)

--- a/index.js
+++ b/index.js
@@ -12,5 +12,5 @@ export {default as treemapDice} from "./src/treemap/dice";
 export {default as treemapSlice} from "./src/treemap/slice";
 export {default as treemapSliceDice} from "./src/treemap/sliceDice";
 export {default as treemapSquarify} from "./src/treemap/squarify";
-export {default as split} from "./src/treemap/split";
+export {default as treemapSplit} from "./src/treemap/split";
 export {default as treemapResquarify} from "./src/treemap/resquarify";

--- a/index.js
+++ b/index.js
@@ -12,4 +12,5 @@ export {default as treemapDice} from "./src/treemap/dice";
 export {default as treemapSlice} from "./src/treemap/slice";
 export {default as treemapSliceDice} from "./src/treemap/sliceDice";
 export {default as treemapSquarify} from "./src/treemap/squarify";
+export {default as split} from "./src/treemap/split";
 export {default as treemapResquarify} from "./src/treemap/resquarify";

--- a/src/treemap/split.js
+++ b/src/treemap/split.js
@@ -10,7 +10,7 @@ export default function(parent, x0, y0, x1, y1) {
     return;
   }
 
-  splitTree(parent.children, null, x0, y0, x1, y1);
+  splitTree(parent.children, parent.value, x0, y0, x1, y1);
 
   function splitTree(nodes, sum, x0, y0, x1, y1) {
 
@@ -26,7 +26,7 @@ export default function(parent, x0, y0, x1, y1) {
       nodes[0].y0 = y0;
       nodes[0].y1 = y1;
       if (nodes[0].children && nodes[0].children.length > 0) {
-        splitTree(nodes[0].children, null, x0, y0, x1, y1);
+        splitTree(nodes[0].children, parent.value, x0, y0, x1, y1);
         return;
       } else {
         return;

--- a/src/treemap/split.js
+++ b/src/treemap/split.js
@@ -1,0 +1,94 @@
+export default function(parent, x0, y0, x1, y1) {
+
+  parent.x0 = x0;
+  parent.x1 = x1;
+  parent.y0 = y0;
+  parent.y1 = y1;
+
+  // exit if no children
+  if (!(parent.children) || parent.children.length === 0) {
+    return;
+  }
+
+  splitTree(parent.children, x0, y0, x1, y1);
+
+  function splitTree(nodes, x0, y0, x1, y1) {
+
+    var i, n = nodes.length;
+
+    if (n === 0) {
+      return;
+    }
+
+    if (n === 1) {
+      nodes[0].x0 = x0;
+      nodes[0].x1 = x1;
+      nodes[0].y0 = y0;
+      nodes[0].y1 = y1;
+      if (nodes[0].children && nodes[0].children.length > 0) {
+        splitTree(nodes[0].children, x0, y0, x1, y1);
+      } else {
+        return;
+      }
+    }
+
+    var sum, sums = new Array(n + 1);
+
+    for (sums[0] = sum = i = 0; i < n; ++i) {
+      sums[i + 1] = sum += nodes[i].value;
+    }
+
+    var width = x1 - x0,
+      height = y1 - y0;
+
+    var list1 = [],
+      list2 = [],
+      r1x0 = 0,
+      r1x1 = 0,
+      r1y0 = 0,
+      r1y1 = 0,
+      r2x0 = 0,
+      r2x1 = 0,
+      r2y0 = 0,
+      r2y1 = 0,
+      halfSize = sum / 2,
+      w1 = 0,
+      tmp = 0;
+
+    for (i = 0; i < n; i++) {
+      tmp += nodes[i].value;
+      if (Math.abs(halfSize - tmp) > Math.abs(halfSize - w1)) {
+        list1 = nodes.slice(0, i);
+        break;
+      }
+      w1 = tmp;
+    }
+
+    list2 = nodes.slice(i);
+
+    if (width > height) {
+      r1x0 = x0;
+      r1y0 = y0;
+      r1x1 = x0 + width * w1 / sum;
+      r1y1 = y1;
+
+      r2x0 = r1x1;
+      r2y0 = y0;
+      r2x1 = x1;
+      r2y1 = y1;
+    } else {
+      r1x0 = x0;
+      r1y0 = y0;
+      r1x1 = x1;
+      r1y1 = y0 + height * w1 / sum;
+
+      r2x0 = x0;
+      r2y0 = r1y1;
+      r2x1 = x1;
+      r2y1 = y1;
+    }
+
+    splitTree(list1, r1x0, r1y0, r1x1, r1y1);
+    splitTree(list2, r2x0, r2y0, r2x1, r2y1);
+  }
+}

--- a/src/treemap/split.js
+++ b/src/treemap/split.js
@@ -71,7 +71,7 @@ export default function(parent, x0, y0, x1, y1) {
     }
 
     list2 = nodes.slice(i);
-    w2 = w1 - sum;
+    w2 = sum - w1;
 
     if (width > height) {
       r1x0 = x0;

--- a/src/treemap/split.js
+++ b/src/treemap/split.js
@@ -12,6 +12,17 @@ export default function(parent, x0, y0, x1, y1) {
 
   splitTree(parent.children, null, x0, y0, x1, y1);
 
+  function calcSum(nodes, n) {
+    // if not provided a sum then calculate
+    //   sum total
+    var sum = 0,
+        i = 0;
+    for ( ; i < n; ++i) {
+      sum += nodes[i].value;
+    }
+    return sum;
+  }
+
   function splitTree(nodes, sum, x0, y0, x1, y1) {
 
     var i, n = nodes.length;
@@ -25,12 +36,7 @@ export default function(parent, x0, y0, x1, y1) {
       nodes[0].x1 = x1;
       nodes[0].y0 = y0;
       nodes[0].y1 = y1;
-      if (nodes[0].children && nodes[0].children.length > 0) {
-        splitTree(nodes[0].children, null, x0, y0, x1, y1);
-        return;
-      } else {
-        return;
-      }
+      return;
     }
 
     var width = x1 - x0,
@@ -53,11 +59,7 @@ export default function(parent, x0, y0, x1, y1) {
 
 
     if (sum === null) {
-      // if not provided a sum then calculate
-      //   sum total
-      for (sum = i = 0; i < n; ++i) {
-        sum += nodes[i].value;
-      }
+      sum = calcSum(nodes, n);
     }
 
     halfSize = sum / 2;

--- a/src/treemap/split.js
+++ b/src/treemap/split.js
@@ -10,7 +10,7 @@ export default function(parent, x0, y0, x1, y1) {
     return;
   }
 
-  splitTree(parent.children, parent.value, x0, y0, x1, y1);
+  splitTree(parent.children, null, x0, y0, x1, y1);
 
   function splitTree(nodes, sum, x0, y0, x1, y1) {
 
@@ -26,7 +26,7 @@ export default function(parent, x0, y0, x1, y1) {
       nodes[0].y0 = y0;
       nodes[0].y1 = y1;
       if (nodes[0].children && nodes[0].children.length > 0) {
-        splitTree(nodes[0].children, parent.value, x0, y0, x1, y1);
+        splitTree(nodes[0].children, null, x0, y0, x1, y1);
         return;
       } else {
         return;

--- a/src/treemap/split.js
+++ b/src/treemap/split.js
@@ -10,9 +10,9 @@ export default function(parent, x0, y0, x1, y1) {
     return;
   }
 
-  splitTree(parent.children, x0, y0, x1, y1);
+  splitTree(parent.children, null, x0, y0, x1, y1);
 
-  function splitTree(nodes, x0, y0, x1, y1) {
+  function splitTree(nodes, sum, x0, y0, x1, y1) {
 
     var i, n = nodes.length;
 
@@ -26,16 +26,11 @@ export default function(parent, x0, y0, x1, y1) {
       nodes[0].y0 = y0;
       nodes[0].y1 = y1;
       if (nodes[0].children && nodes[0].children.length > 0) {
-        splitTree(nodes[0].children, x0, y0, x1, y1);
+        splitTree(nodes[0].children, null, x0, y0, x1, y1);
+        return;
       } else {
         return;
       }
-    }
-
-    var sum, sums = new Array(n + 1);
-
-    for (sums[0] = sum = i = 0; i < n; ++i) {
-      sums[i + 1] = sum += nodes[i].value;
     }
 
     var width = x1 - x0,
@@ -51,10 +46,21 @@ export default function(parent, x0, y0, x1, y1) {
       r2x1 = 0,
       r2y0 = 0,
       r2y1 = 0,
-      halfSize = sum / 2,
+      halfSize = 0,
+      tmp = 0,
       w1 = 0,
-      tmp = 0;
+      w2 = 0;
 
+
+    if (sum === null) {
+      // if not provided a sum then calculate
+      //   sum total
+      for (sum = i = 0; i < n; ++i) {
+        sum += nodes[i].value;
+      }
+    }
+
+    halfSize = sum / 2;
     for (i = 0; i < n; i++) {
       tmp += nodes[i].value;
       if (Math.abs(halfSize - tmp) > Math.abs(halfSize - w1)) {
@@ -65,6 +71,7 @@ export default function(parent, x0, y0, x1, y1) {
     }
 
     list2 = nodes.slice(i);
+    w2 = w1 - sum;
 
     if (width > height) {
       r1x0 = x0;
@@ -88,7 +95,11 @@ export default function(parent, x0, y0, x1, y1) {
       r2y1 = y1;
     }
 
-    splitTree(list1, r1x0, r1y0, r1x1, r1y1);
-    splitTree(list2, r2x0, r2y0, r2x1, r2y1);
+    if (list1.length > 0 && w1 > 0) {
+      splitTree(list1, w1, r1x0, r1y0, r1x1, r1y1);
+    }
+    if (list2.length > 0 && w2 > 0 ) {
+      splitTree(list2, w2, r2x0, r2y0, r2x1, r2y1);
+    }
   }
 }

--- a/src/treemap/split.js
+++ b/src/treemap/split.js
@@ -1,27 +1,25 @@
 export default function(parent, x0, y0, x1, y1) {
 
-  parent.x0 = x0;
-  parent.x1 = x1;
-  parent.y0 = y0;
-  parent.y1 = y1;
-
   // exit if no children
   if (!(parent.children) || parent.children.length === 0) {
     return;
   }
 
-  splitTree(parent.children, null, x0, y0, x1, y1);
-
-  function calcSum(nodes, n) {
-    // if not provided a sum then calculate
-    //   sum total
+  function calcSum(nodes) {
     var sum = 0,
-        i = 0;
+      i = 0,
+      n = nodes.length;
+
     for ( ; i < n; ++i) {
       sum += nodes[i].value;
     }
     return sum;
   }
+
+  var sum = calcSum(parent.children);
+
+  splitTree(parent.children, sum, x0, y0, x1, y1);
+
 
   function splitTree(nodes, sum, x0, y0, x1, y1) {
 
@@ -56,11 +54,6 @@ export default function(parent, x0, y0, x1, y1) {
       tmp = 0,
       w1 = 0,
       w2 = 0;
-
-
-    if (sum === null) {
-      sum = calcSum(nodes, n);
-    }
 
     halfSize = sum / 2;
     for (i = 0; i < n; i++) {

--- a/test/treemap/split-test.js
+++ b/test/treemap/split-test.js
@@ -1,0 +1,30 @@
+var tape = require("tape"),
+    d3_hierarchy = require("../../"),
+    round = require("./round");
+
+tape("treemapSplit(parent, x0, y0, x1, y1) generates a split treemap layout", function(test) {
+  var tile = d3_hierarchy.treemapSplit,
+      root = {
+        value: 24,
+        children: [
+          {value: 6},
+          {value: 6},
+          {value: 4},
+          {value: 3},
+          {value: 2},
+          {value: 2},
+          {value: 1}
+        ]
+      };
+  tile(root, 0, 0, 6, 4);
+  test.deepEqual(root.children.map(round), [
+    {x0: 0.00, x1: 3.00, y0: 0.00, y1: 2.00},
+    {x0: 0.00, x1: 3.00, y0: 2.00, y1: 4.00},
+    {x0: 3.00, x1: 4.71, y0: 0.00, y1: 2.33},
+    {x0: 4.71, x1: 6.00, y0: 0.00, y1: 2.33},
+    {x0: 3.00, x1: 4.20, y0: 2.33, y1: 4.00},
+    {x0: 4.20, x1: 5.40, y0: 2.33, y1: 4.00},
+    {x0: 5.40, x1: 6.00, y0: 2.33, y1: 4.00}
+  ]);
+  test.end();
+});


### PR DESCRIPTION
This pull (#71) seeks to add the split algorithm as `d3.treemapSplit`.

### References:

- "Ordered and Unordered Treemap Algorithms and Their Applications on Handheld Devices" by BJÖRN ENGDAHL, 2005 ([link(pdf)](https://www.nada.kth.se/utbildning/grukth/exjobb/rapportlistor/2005/rapporter05/engdahl_bjorn_05033.pdf))
- `ggraph` implementation by @thomasp85 https://github.com/thomasp85/ggraph/blob/faf8b2011958ecc9be098122619d946f3aed8171/src/treemap.cpp

### Examples

http://bl.ocks.org/timelyportfolio/2bbd4cedf597eae6a5e90412d9df1c1f
http://bl.ocks.org/timelyportfolio/e480359ea953d96a38a4466187d3d62b

### Todo

- [x] add test~s~ (f73f12b)
- [ ] refactor to more closely mirror `d3` style
- [x] document (60cbfed)