### PR TITLE
feature/accessors-for-immutable-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var treemap = d3.treemap();
 
 Before you can compute a hierarchical layout, you need a root node. If your data is already in a hierarchical format, such as JSON, you can pass it directly to [d3.hierarchy](#hierarchy); otherwise, you can rearrange tabular data, such as comma-separated values (CSV), into a hierarchy using [d3.stratify](#stratify).
 
-<a name="hierarchy" href="#hierarchy">#</a> d3.<b>hierarchy</b>(<i>data</i>[, <i>children</i>]) [<>](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/index.js#L12 "Source")
+<a name="hierarchy" href="#hierarchy">#</a> d3.<b>hierarchy</b>(<i>data</i>[, <i>children</i>, <i>lengthAccessor</i>, <i>childAccessor</i>]) [<>](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/index.js#L12 "Source")
 
 Constructs a root node from the specified hierarchical *data*. The specified *data* must be an object representing the root node. For example:
 
@@ -85,6 +85,22 @@ The specified *children* accessor function is invoked for each datum, starting w
 ```js
 function children(d) {
   return d.children;
+}
+```
+
+The specified *lengthAccessor* function is invoked for each datum's children, it must return a number relating to the length of the children list. This provides a hook for data structures to resolve the length of their children if `length` isn't specified on the object.  If *lengthAccessor* is not specified, it defaults to:
+
+```js
+function defaultLength(d) {
+  return d.length;
+}
+```
+
+The specified *childAccessor* function is invoked when accessing the nodes in the list of children. This provides a hook for accessing the nodes in the child list, if they are not a standard array. If *childAccessor* is not specified, it defaults to:
+
+```js
+function defaultChild(d, i) {
+  return d[i];
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-hierarchy",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Layout algorithms for visualizing hierarchical data.",
   "keywords": [
     "d3",

--- a/src/hierarchy/index.js
+++ b/src/hierarchy/index.js
@@ -10,7 +10,7 @@ import node_descendants from "./descendants";
 import node_leaves from "./leaves";
 import node_links from "./links";
 
-export default function hierarchy(data, children) {
+export default function hierarchy(data, children, lengthAccessor, childAccessor) {
   var root = new Node(data),
       valued = +data.value && (root.value = data.value),
       node,
@@ -21,13 +21,15 @@ export default function hierarchy(data, children) {
       n;
 
   if (children == null) children = defaultChildren;
+  if (lengthAccessor == null) lengthAccessor = defaultLength;
+  if (childAccessor == null) childAccessor = defaultChild;
 
   while (node = nodes.pop()) {
     if (valued) node.value = +node.data.value;
-    if ((childs = children(node.data)) && (n = childs.length)) {
+    if ((childs = children(node.data)) && (n = lengthAccessor(childs))) {
       node.children = new Array(n);
       for (i = n - 1; i >= 0; --i) {
-        nodes.push(child = node.children[i] = new Node(childs[i]));
+        nodes.push(child = node.children[i] = new Node(childAccessor(childs, i)));
         child.parent = node;
         child.depth = node.depth + 1;
       }
@@ -43,6 +45,14 @@ function node_copy() {
 
 function defaultChildren(d) {
   return d.children;
+}
+
+function defaultLength(d) {
+  return d.length;
+}
+
+function defaultChild(d, i) {
+  return d[i];
 }
 
 function copyData(node) {


### PR DESCRIPTION
Adding length, and child accessors to support Array-like models (immutable) which don't provide the same interface as Arrays. Specifically being able to provide these functions allows consumers specify functions for accessing the length of their children, as well as accessing the item within the list