### PR TITLE
Test for inconsistencies between place() and intersects()

### DIFF
--- a/src/pack/siblings.js
+++ b/src/pack/siblings.js
@@ -5,13 +5,20 @@ function place(a, b, c) {
       dy = b.y - a.y,
       dc = dx * dx + dy * dy;
   if (dc) {
-    var k = 2 * dc,
-        da = a.r * a.r + 2 * a.r * c.r + c.r * c.r,
-        db = b.r * b.r + 2 * b.r * c.r + c.r * c.r,
-        x = (dc + da - db) / k,
-        y = Math.sqrt(Math.max(0, 2 * (db * da + db * dc + da * dc) - db * db - da * da - dc * dc)) / k;
-    c.x = a.x + x * dx + y * dy;
-    c.y = a.y + x * dy - y * dx;
+    var scale = Math.sqrt(dc);
+    var ar = a.r / scale, br = b.r / scale, cr = c.r / scale;
+    var x, y;
+     if (a.r > b.r) {
+      x = (1 - (ar - br) * (ar + br + 2*cr)) / 2;
+      y = Math.sqrt(Math.max(0, (br + cr) * (br + cr) - x * x));
+      c.x = b.x - x * dx - y * dy;
+      c.y = b.y - x * dy + y * dx;
+    } else {
+      x = (1 - (br - ar) * (ar + br + 2*cr)) / 2;
+      y = Math.sqrt(Math.max(0, (ar + cr) * (ar + cr) - x * x));
+      c.x = a.x + x * dx - y * dy;
+      c.y = a.y + x * dy + y * dx;
+    }
   } else {
     c.x = a.x + a.r + c.r;
     c.y = a.y;

--- a/src/pack/siblings.js
+++ b/src/pack/siblings.js
@@ -5,17 +5,15 @@ function place(a, b, c) {
       dy = b.y - a.y,
       dc = dx * dx + dy * dy;
   if (dc) {
-    var scale = Math.sqrt(dc);
-    var ar = a.r / scale, br = b.r / scale, cr = c.r / scale;
     var x, y;
      if (a.r > b.r) {
-      x = (1 - (ar - br) * (ar + br + 2*cr)) / 2;
-      y = Math.sqrt(Math.max(0, (br + cr) * (br + cr) - x * x));
+      x = (1 - (a.r - b.r) * (a.r + b.r + 2*c.r) / dc) / 2;
+      y = Math.sqrt(Math.max(0, (b.r + c.r) * (b.r + c.r) / dc - x * x));
       c.x = b.x - x * dx - y * dy;
       c.y = b.y - x * dy + y * dx;
     } else {
-      x = (1 - (br - ar) * (ar + br + 2*cr)) / 2;
-      y = Math.sqrt(Math.max(0, (ar + cr) * (ar + cr) - x * x));
+      x = (1 - (b.r - a.r) * (a.r + b.r + 2*c.r) / dc) / 2;
+      y = Math.sqrt(Math.max(0, (a.r + c.r) * (a.r + c.r) / dc - x * x));
       c.x = a.x + x * dx - y * dy;
       c.y = a.y + x * dy + y * dx;
     }

--- a/test/pack/find-place-bugs.js
+++ b/test/pack/find-place-bugs.js
@@ -34,20 +34,20 @@ function intersects(a, b) {
 // Create n random circles.
 // The first two are placed touching on the x-axis; the rest are unplaced
 function randomCircles(n) {
-	const r = [];
-	for (var i = 0; i < n; i++) {
-		r.push({ r: Math.random() * (1 << (Math.random() * 30)) });
-	}
-	r[0].x = -r[1].r, r[1].x = r[0].r, r[0].y = r[1].y = 0;
-	return r;
+  const r = [];
+  for (var i = 0; i < n; i++) {
+    r.push({ r: Math.random() * (1 << (Math.random() * 30)) });
+  }
+  r[0].x = -r[1].r, r[1].x = r[0].r, r[0].y = r[1].y = 0;
+  return r;
 }
 
 function test() {
-	for(;;) {
-		const [a,b,c,d] = randomCircles(4);
-		place(b, a, c);
-		place(a, c, d);
-	}
+  for(;;) {
+    const [a,b,c,d] = randomCircles(4);
+    place(b, a, c);
+    place(a, c, d);
+  }
 }
 
 test();

--- a/test/pack/find-place-bugs.js
+++ b/test/pack/find-place-bugs.js
@@ -19,7 +19,9 @@ function place(a, b, c) {
     c.y = a.y;
   }
   if (intersects(a, c) || intersects(b, c)) {
-    console.log(a, b, c);
+    console.log(`a = {x: ${a.x}, y: ${a.y}, r: ${a.r}},`);
+    console.log(`b = {x: ${b.x}, y: ${b.y}, r: ${b.r}},`);
+    console.log(`c = {r: ${c.r}}`);
     throw new Error;
   }
 }

--- a/test/pack/find-place-bugs.js
+++ b/test/pack/find-place-bugs.js
@@ -7,17 +7,15 @@ function place(a, b, c) {
       dy = b.y - a.y,
       dc = dx * dx + dy * dy;
   if (dc) {
-    var scale = Math.sqrt(dc);
-    var ar = a.r / scale, br = b.r / scale, cr = c.r / scale;
     var x, y;
      if (a.r > b.r) {
-      x = (1 - (ar - br) * (ar + br + 2*cr)) / 2;
-      y = Math.sqrt(Math.max(0, (br + cr) * (br + cr) - x * x));
+      x = (1 - (a.r - b.r) * (a.r + b.r + 2*c.r) / dc) / 2;
+      y = Math.sqrt(Math.max(0, (b.r + c.r) * (b.r + c.r) / dc - x * x));
       c.x = b.x - x * dx - y * dy;
       c.y = b.y - x * dy + y * dx;
     } else {
-      x = (1 - (br - ar) * (ar + br + 2*cr)) / 2;
-      y = Math.sqrt(Math.max(0, (ar + cr) * (ar + cr) - x * x));
+      x = (1 - (b.r - a.r) * (a.r + b.r + 2*c.r) / dc) / 2;
+      y = Math.sqrt(Math.max(0, (a.r + c.r) * (a.r + c.r) / dc - x * x));
       c.x = a.x + x * dx - y * dy;
       c.y = a.y + x * dy + y * dx;
     }

--- a/test/pack/find-place-bugs.js
+++ b/test/pack/find-place-bugs.js
@@ -1,0 +1,51 @@
+// Look for numerical inconsistencies between the place() and intersects()
+// methods from pack/siblings.js
+
+// The place and intersect functions are not exported, so we duplicate them here
+function place(a, b, c) {
+  var dx = b.x - a.x,
+      dy = b.y - a.y,
+      dc = dx * dx + dy * dy;
+  if (dc) {
+    var k = 2 * dc,
+        da = a.r * a.r + 2 * a.r * c.r + c.r * c.r,
+        db = b.r * b.r + 2 * b.r * c.r + c.r * c.r,
+        x = (dc + da - db) / k,
+        y = Math.sqrt(Math.max(0, 2 * (db * da + db * dc + da * dc) - db * db - da * da - dc * dc)) / k;
+    c.x = a.x + x * dx + y * dy;
+    c.y = a.y + x * dy - y * dx;
+  } else {
+    c.x = a.x + a.r + c.r;
+    c.y = a.y;
+  }
+  if (intersects(a, c) || intersects(b, c)) {
+    console.log(a, b, c);
+    throw new Error;
+  }
+}
+
+function intersects(a, b) {
+  var dr = a.r + b.r - 1e-6, dx = b.x - a.x, dy = b.y - a.y;
+  return dr > 0 && dr * dr > dx * dx + dy * dy;
+}
+
+// Create n random circles.
+// The first two are placed touching on the x-axis; the rest are unplaced
+function randomCircles(n) {
+	const r = [];
+	for (var i = 0; i < n; i++) {
+		r.push({ r: Math.random() * (1 << (Math.random() * 30)) });
+	}
+	r[0].x = -r[1].r, r[1].x = r[0].r, r[0].y = r[1].y = 0;
+	return r;
+}
+
+function test() {
+	for(;;) {
+		const [a,b,c,d] = randomCircles(4);
+		place(b, a, c);
+		place(a, c, d);
+	}
+}
+
+test();

--- a/test/pack/find-place-bugs.js
+++ b/test/pack/find-place-bugs.js
@@ -7,22 +7,31 @@ function place(a, b, c) {
       dy = b.y - a.y,
       dc = dx * dx + dy * dy;
   if (dc) {
-    var k = 2 * dc,
-        da = a.r * a.r + 2 * a.r * c.r + c.r * c.r,
-        db = b.r * b.r + 2 * b.r * c.r + c.r * c.r,
-        x = (dc + da - db) / k,
-        y = Math.sqrt(Math.max(0, 2 * (db * da + db * dc + da * dc) - db * db - da * da - dc * dc)) / k;
-    c.x = a.x + x * dx + y * dy;
-    c.y = a.y + x * dy - y * dx;
+    var scale = Math.sqrt(dc);
+    var ar = a.r / scale, br = b.r / scale, cr = c.r / scale;
+    var x, y;
+     if (a.r > b.r) {
+      x = (1 - (ar - br) * (ar + br + 2*cr)) / 2;
+      y = Math.sqrt(Math.max(0, (br + cr) * (br + cr) - x * x));
+      c.x = b.x - x * dx - y * dy;
+      c.y = b.y - x * dy + y * dx;
+    } else {
+      x = (1 - (br - ar) * (ar + br + 2*cr)) / 2;
+      y = Math.sqrt(Math.max(0, (ar + cr) * (ar + cr) - x * x));
+      c.x = a.x + x * dx - y * dy;
+      c.y = a.y + x * dy + y * dx;
+    }
   } else {
     c.x = a.x + a.r + c.r;
     c.y = a.y;
   }
+
+  // This last part is not part of the original function!
   if (intersects(a, c) || intersects(b, c)) {
     console.log(`a = {x: ${a.x}, y: ${a.y}, r: ${a.r}},`);
     console.log(`b = {x: ${b.x}, y: ${b.y}, r: ${b.r}},`);
     console.log(`c = {r: ${c.r}}`);
-    throw new Error;
+    console.log();
   }
 }
 

--- a/test/pack/siblings-test.js
+++ b/test/pack/siblings-test.js
@@ -69,8 +69,6 @@ function intersectsAny(circles) {
 }
 
 function intersects(a, b) {
-  var dx = b.x - a.x,
-      dy = b.y - a.y,
-      dr = a.r + b.r;
-  return dr * dr - 1e-6 > dx * dx + dy * dy;
+  var dr = a.r + b.r - 1e-6, dx = b.x - a.x, dy = b.y - a.y;
+  return dr > 0 && dr * dr > dx * dx + dy * dy;
 }


### PR DESCRIPTION
Improved `place(a, b, c)` function that avoids overlaps between c and a or b.

Note that `flare-test.js` fails. I haven’t investigated why: I hope it is simply a result of the changes in numerical precision causing slightly different circle placements.

See discussion on #111. Fixes #109.