### PR TITLE
Readme.md für d3.hierarchy contains wrong description for node.eachBefore(f)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "infovis"
   ],
   "homepage": "https://github.com/d3/d3-hierarchy",
-  "license" : "BSD-3-Clause",
+  "license": "BSD-3-Clause",
   "author": {
     "name": "Mike Bostock",
     "url": "http://bost.ocks.org/mike"
@@ -26,6 +26,9 @@
     "pretest": "mkdir -p build && node -e 'process.stdout.write(\"var version = \\\"\" + require(\"./package.json\").version + \"\\\"; export * from \\\"../index\\\"; export {version};\");' > build/bundle.js && rollup -f umd -u d3-hierarchy -n d3_hierarchy -o build/d3-hierarchy.js -- build/bundle.js",
     "test": "faucet `find test -name '*-test.js'`",
     "prepublish": "npm run test && uglifyjs build/d3-hierarchy.js -c -m -o build/d3-hierarchy.min.js && rm -f build/d3-hierarchy.zip && zip -j build/d3-hierarchy.zip -- LICENSE README.md build/d3-hierarchy.js build/d3-hierarchy.min.js"
+  },
+  "dependencies": {
+    "d3-arrays": "~0.3.0"
   },
   "devDependencies": {
     "faucet": "0.0",

--- a/src/hierarchy.js
+++ b/src/hierarchy.js
@@ -1,8 +1,17 @@
+import {map} from "d3-arrays";
 import {visitAfter, visitBefore} from "./visit";
 import links from "./links";
 
-function defaultChildren(d) {
-  return d.children;
+// function defaultChildren(d) {
+//   return d.children;
+// }
+
+function defaultId(d, i) {
+  return i;
+}
+
+function defaultParentId(d) {
+  return d.parent;
 }
 
 function defaultValue(d) {
@@ -20,10 +29,15 @@ export function rebind(layout, hierarchy) {
     return x === hierarchy ? layout : x;
   };
 
-  layout.children = function() {
-    var x = hierarchy.children.apply(hierarchy, arguments);
+  layout.parentId = function() {
+    var x = hierarchy.parentId.apply(hierarchy, arguments);
     return x === hierarchy ? layout : x;
   };
+
+  // layout.children = function() {
+  //   var x = hierarchy.children.apply(hierarchy, arguments);
+  //   return x === hierarchy ? layout : x;
+  // };
 
   layout.value = function() {
     var x = hierarchy.value.apply(hierarchy, arguments);
@@ -38,72 +52,154 @@ export function rebind(layout, hierarchy) {
 
 export default function() {
   var sort = defaultSort,
-      children = defaultChildren,
+      id = defaultId,
+      parentId = defaultParentId,
       value = defaultValue;
 
-  function hierarchy(root) {
-    var stack = [root],
-        nodes = [],
-        node;
+  // function hierarchy(root) {
+  //   var stack = [root],
+  //       nodes = [],
+  //       node;
+  //
+  //   root.parent = null;
+  //   root.depth = 0;
+  //
+  //   while ((node = stack.pop()) != null) {
+  //     nodes.push(node);
+  //     if ((childs = children.call(hierarchy, node, node.depth)) && (n = childs.length)) {
+  //       var n, childs, child;
+  //       while (--n >= 0) {
+  //         stack.push(child = childs[n]);
+  //         child.parent = node;
+  //         child.depth = node.depth + 1;
+  //       }
+  //       if (value) node.value = 0;
+  //       node.children = childs;
+  //     } else {
+  //       if (value) node.value = +value.call(hierarchy, node, node.depth) || 0;
+  //       delete node.children;
+  //     }
+  //   }
+  //
+  //   visitAfter(root, function(node) {
+  //     var childs, parent;
+  //     if (sort && (childs = node.children)) childs.sort(sort);
+  //     if (value && (parent = node.parent)) parent.value += node.value;
+  //   });
+  //
+  //   return nodes;
+  // }
 
-    root.parent = null;
-    root.depth = 0;
+  function hierarchy(data) {
+    var i,
+        n = data.length,
+        nodeById = map(),
+        nodes = new Array(n);
 
-    while ((node = stack.pop()) != null) {
-      nodes.push(node);
-      if ((childs = children.call(hierarchy, node, node.depth)) && (n = childs.length)) {
-        var n, childs, child;
-        while (--n >= 0) {
-          stack.push(child = childs[n]);
-          child.parent = node;
-          child.depth = node.depth + 1;
-        }
-        if (value) node.value = 0;
-        node.children = childs;
+    // Create the wrapper nodes and compute the value of each node.
+    //
+    // TODO Previously when we computed the value, we knew the depth of the
+    // node. Related: previously the this context of the children and value
+    // accessors was the hierarchy function, but that’s bogus because it would
+    // be the base hierarchy instance rather than the intended subclass (such as
+    // a treemap layout instance). Maybe there’s a way to preserve that context
+    // but it doesn’t seem particularly useful. Maybe the this context should be
+    // the node? That would make it kind of like selections…
+    //
+    // TODO Also, we only computed the value for leaf nodes, whereas this is
+    // going to invoke the value function for all nodes. So, we’ll need to
+    // differentiate between the internal (self) value and the subtree value.
+    for (i = 0; i < n; ++i) {
+      var d = data[i],
+          nodeId = id(d, i) + "";
+      if (!nodeById.has(nodeId)) {
+        nodeById.set(nodeId, nodes[i] = {
+          id: nodeId,
+          data: d,
+          value: +value(d, i), // Note: no longer coerces value to 0 if NaN.
+          depth: 0,
+          children: null,
+          parent: null
+        });
       } else {
-        if (value) node.value = +value.call(hierarchy, node, node.depth) || 0;
-        delete node.children;
+        throw new Error("duplicate node: " + nodeId);
       }
     }
 
-    visitAfter(root, function(node) {
-      var childs, parent;
-      if (sort && (childs = node.children)) childs.sort(sort);
-      if (value && (parent = node.parent)) parent.value += node.value;
-    });
+    // Connect parent and child.
+    //
+    // NOTE It might be nice to define the parent by reference rather than by
+    // id, but I don’t think that’s feasible: we’d need to go from the input
+    // datum to its wrapper node. We could set a reference on the input data,
+    // but we want to avoid mutating the input; and, iterating over all the
+    // input data to find the corresponding node would be slow.
+    //
+    // TODO Is there an easy way of implicitly defining internal nodes? For
+    // example if you have a set of classes in a package hierarchy, maybe you
+    // just have the names of the classes and don’t want to also enumerate the
+    // packages that contain them. But I think this would require an accessor
+    // that enumerates all the ancestor ids (e.g., "java.lang.Number",
+    // "java.lang", "java") for a given datum rather than just the parent id.
+    //
+    // TODO How do we handle multiple roots? We could create an implicit root?
+    // Should we return an array of roots?
+    for (i = 0; i < n; ++i) {
+      var d = data[i],
+          child = nodes[i],
+          parentNodeId = parentId(d, i) + "",
+          parent = nodeById.get(parentNodeId);
+      if (parent) {
+        child.parent = parent;
+        if (parent.children) parent.children.push(child);
+        else parent.children = [child];
+      } else {
+        throw new Error("parent not found: " + parentNodeId);
+      }
+    }
 
-    return nodes;
+    // Compute child depth.
+    //
+    // We could do this in the previous pass, but it would require recursively
+    // descending into each child which could be quadratic time.
   }
 
-  hierarchy.nodes = hierarchy;
-
-  hierarchy.links = links;
+  // hierarchy.nodes = hierarchy;
+  // hierarchy.links = links;
 
   hierarchy.sort = function(x) {
     return arguments.length ? (sort = x, hierarchy) : sort;
   };
 
-  hierarchy.children = function(x) {
-    return arguments.length ? (children = x, hierarchy) : children;
+  hierarchy.id = function(x) {
+    return arguments.length ? (id = x, hierarchy) : id;
   };
 
+  hierarchy.parentId = function(x) {
+    return arguments.length ? (parentId = x, hierarchy) : parentId;
+  };
+
+  // hierarchy.children = function(x) {
+  //   return arguments.length ? (children = x, hierarchy) : children;
+  // };
+
+  // TODO Allow this to be set to null?
   hierarchy.value = function(x) {
     return arguments.length ? (value = x, hierarchy) : value;
   };
 
-  hierarchy.revalue = function(root) {
-    if (value) {
-      visitBefore(root, function(node) {
-        if (node.children) node.value = 0;
-      });
-      visitAfter(root, function(node) {
-        var parent;
-        if (!node.children) node.value = +value.call(hierarchy, node, node.depth) || 0;
-        if (parent = node.parent) parent.value += node.value;
-      });
-    }
-    return root;
-  };
+  // hierarchy.revalue = function(root) {
+  //   if (value) {
+  //     visitBefore(root, function(node) {
+  //       if (node.children) node.value = 0;
+  //     });
+  //     visitAfter(root, function(node) {
+  //       var parent;
+  //       if (!node.children) node.value = +value.call(hierarchy, node, node.depth) || 0;
+  //       if (parent = node.parent) parent.value += node.value;
+  //     });
+  //   }
+  //   return root;
+  // };
 
   return hierarchy;
 };


### PR DESCRIPTION
# node.eachBefore(function) <>

Invokes the specified function for node and each descendant in pre-order traversal, such that a given node is only visited after all of its ancestors have already been visited. The specified function is passed the current node.

should be changed to
# node.eachBefore(function) <>

Invokes the specified function for node and each descendant in pre-order traversal, such that a given node is visited before all of its ancestors are visited. The specified function is passed the current node.