### PR TITLE
Change function syntax.

### DIFF
--- a/src/hierarchy/links.js
+++ b/src/hierarchy/links.js
@@ -1,9 +1,8 @@
 export default function() {
-  var root = this, links = [];
-  root.each(function(node) {
-    if (node !== root) { // Don’t include the root’s parent, if any.
-      links.push({source: node.parent, target: node});
-    }
+  const root = this;
+  const links = [];
+  root.each((node) => {
+    node !== root && links.push({source: node.parent, target: node});
   });
   return links;
 }


### PR DESCRIPTION
1. Separate variables declaration.
2. Change to arrow syntax.
3. Change if/else to short-circuit evaluation.