### PR TITLE
hierarchify

### DIFF
--- a/src/hierarchify.js
+++ b/src/hierarchify.js
@@ -1,0 +1,27 @@
+import {stratify} from "./stratify.js";
+
+export default function hierarchify(data, path) {
+  if (typeof path !== "function") throw new Error("invalid path function");
+  const D = [...data];
+  const I = D.map((d, i) => normalize(path(d, i, data)));
+  const P = I.map(parentof);
+  const S = new Set(I);
+  for (const i of P) {
+    if (!S.has(i) && i) {
+      S.add(i);
+      D.push({path: i});
+      I.push(i);
+      P.push(parentof(i));
+    }
+  }
+  return stratify(D, {id: (_, i) => I[i], parentId: (_i, i) => P[i]});
+}
+
+function normalize(path) {
+  path = `${path}`.replace(/\/$/, ""); // coerce to string; strip trailing slash
+  return path.startsWith("/") ? path : `/${path}`; // add leading slash if needed
+}
+
+function parentof(path) {
+  return path === "/" ? "" : path.substring(0, Math.max(1, path.lastIndexOf("/")));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export {default as cluster} from "./cluster.js";
+export {default as hierarchify} from "./hierarchify.js";
 export {default as hierarchy, Node} from "./hierarchy/index.js";
 export {default as pack} from "./pack/index.js";
 export {default as packSiblings} from "./pack/siblings.js";

--- a/src/stratify.js
+++ b/src/stratify.js
@@ -1,75 +1,66 @@
 import {required} from "./accessors.js";
 import {Node, computeHeight} from "./hierarchy/index.js";
 
-var preroot = {depth: -1},
-    ambiguous = {};
+const preroot = {depth: -1};
+const ambiguous = {};
+const defaultId = d => d.id;
+const defaultParentId = d => d.parentId;
 
-function defaultId(d) {
-  return d.id;
-}
+export function stratify(data, {
+  id = defaultId,
+  parentId = defaultParentId
+} = {}) {
+  if (typeof id !== "function") throw new Error("invalid id function");
+  if (typeof parentId !== "function") throw new Error("invalid parentId function");
 
-function defaultParentId(d) {
-  return d.parentId;
-}
+  const nodes = Array.from(data);
+  const n = nodes.length;
+  let root;
+  const nodeByKey = new Map;
 
-export default function() {
-  var id = defaultId,
-      parentId = defaultParentId;
-
-  function stratify(data) {
-    var nodes = Array.from(data),
-        n = nodes.length,
-        d,
-        i,
-        root,
-        parent,
-        node,
-        nodeId,
-        nodeKey,
-        nodeByKey = new Map;
-
-    for (i = 0; i < n; ++i) {
-      d = nodes[i], node = nodes[i] = new Node(d);
-      if ((nodeId = id(d, i, data)) != null && (nodeId += "")) {
-        nodeKey = node.id = nodeId;
-        nodeByKey.set(nodeKey, nodeByKey.has(nodeKey) ? ambiguous : node);
-      }
-      if ((nodeId = parentId(d, i, data)) != null && (nodeId += "")) {
-        node.parent = nodeId;
-      }
+  for (let i = 0; i < n; ++i) {
+    const d = nodes[i];
+    const node = nodes[i] = new Node(d);
+    let nodeId;
+    if ((nodeId = id(d, i, data)) != null && (nodeId = `${nodeId}`)) {
+      nodeByKey.set(node.id = nodeId, nodeByKey.has(nodeId) ? ambiguous : node);
     }
-
-    for (i = 0; i < n; ++i) {
-      node = nodes[i];
-      if (nodeId = node.parent) {
-        parent = nodeByKey.get(nodeId);
-        if (!parent) throw new Error("missing: " + nodeId);
-        if (parent === ambiguous) throw new Error("ambiguous: " + nodeId);
-        if (parent.children) parent.children.push(node);
-        else parent.children = [node];
-        node.parent = parent;
-      } else {
-        if (root) throw new Error("multiple roots");
-        root = node;
-      }
+    if ((nodeId = parentId(d, i, data)) != null && (nodeId = `${nodeId}`)) {
+      node.parent = nodeId;
     }
-
-    if (!root) throw new Error("no root");
-    root.parent = preroot;
-    root.eachBefore(function(node) { node.depth = node.parent.depth + 1; --n; }).eachBefore(computeHeight);
-    root.parent = null;
-    if (n > 0) throw new Error("cycle");
-
-    return root;
   }
 
-  stratify.id = function(x) {
-    return arguments.length ? (id = required(x), stratify) : id;
-  };
+  for (let i = 0; i < n; ++i) {
+    const node = nodes[i];
+    const parentId = node.parent;
+    if (parentId) {
+      const parent = nodeByKey.get(parentId);
+      if (!parent) throw new Error(`missing: ${parentId}`);
+      if (parent === ambiguous) throw new Error(`ambiguous: ${parentId}`);
+      if (parent.children) parent.children.push(node);
+      else parent.children = [node];
+      node.parent = parent;
+    } else {
+      if (root) throw new Error("multiple roots");
+      root = node;
+    }
+  }
 
-  stratify.parentId = function(x) {
-    return arguments.length ? (parentId = required(x), stratify) : parentId;
-  };
+  if (!root) throw new Error("no root");
+  root.parent = preroot;
+  let i = 0;
+  root.eachBefore((node) => { node.depth = node.parent.depth + 1; ++i; });
+  root.eachBefore(computeHeight);
+  root.parent = null;
+  if (i < n) throw new Error("cycle");
 
-  return stratify;
+  return root;
+}
+
+export default function Stratify() {
+  let options = {id: defaultId, parentId: defaultParentId};
+  return Object.assign(data => stratify(data, options), {
+    id(x) { return arguments.length ? (options.id = required(x), this) : options.id; },
+    parentId(x) { return arguments.length ? (options.parentId = required(x), this) : options.parentId; }
+  });
 }

--- a/test/hierarchify-test.js
+++ b/test/hierarchify-test.js
@@ -1,0 +1,405 @@
+import assert from "assert";
+import {hierarchy, hierarchify} from "../src/index.js";
+
+it("hierarchify(data, path) returns the root node", () => {
+  const root = hierarchify([
+    {path: "/"},
+    {path: "/aa"},
+    {path: "/ab"},
+    {path: "/aa/aaa"}
+  ], d => d.path);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      },
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      }
+    ]
+  });
+});
+
+it("hierarchify(data, path) imputes internal nodes", () => {
+  const root = hierarchify([
+    {path: "/aa/aaa"},
+    {path: "/ab"}
+  ], d => d.path);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      },
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("hierarchify(data, path) allows duplicate leaf paths", () => {
+  const root = hierarchify([
+    {path: "/aa/aaa"},
+    {path: "/aa/aaa"},
+  ], d => d.path);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          },
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("hierarchify(data, path) does not allow duplicate internal paths", () => {
+  assert.throws(() => {
+    hierarchify([
+      {path: "/aa"},
+      {path: "/aa"},
+      {path: "/aa/aaa"},
+      {path: "/aa/aaa"},
+    ], d => d.path);
+  }, /ambiguous/);
+});
+
+it("hierarchify(data, path) implicitly adds leading slashes", () => {
+  const root = hierarchify([
+    {path: ""},
+    {path: "aa"},
+    {path: "ab"},
+    {path: "aa/aaa"}
+  ], d => d.path);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: ""},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "aa/aaa"}
+          }
+        ]
+      },
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "ab"}
+      }
+    ]
+  });
+});
+
+it("hierarchify(data, path) implicitly trims trailing slashes", () => {
+  const root = hierarchify([
+    {path: "/aa/"},
+    {path: "/ab/"},
+    {path: "/aa/aaa/"}
+  ], d => d.path);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa/"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa/"}
+          }
+        ]
+      },
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab/"}
+      }
+    ]
+  });
+});
+
+it("hierarchify(data, path) trims at most one trailing slash", () => {
+  const root = hierarchify([
+    {path: "/aa///"}
+  ], d => d.path);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 3,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 2,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/",
+            depth: 2,
+            height: 1,
+            data: {path: "/aa/"},
+            children: [
+              {
+                id: "/aa//",
+                depth: 3,
+                height: 0,
+                data: {path: "/aa///"},
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("hierarchify(data, path) does not require the data to be in topological order", () => {
+  const root = hierarchify([
+    {path: "/aa/aaa"},
+    {path: "/aa"},
+    {path: "/ab"}
+  ], d => d.path);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      },
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      }
+    ]
+  });
+});
+
+it("hierarchify(data, path) preserves the input order of siblings", () => {
+  const root = hierarchify([
+    {path: "/ab"},
+    {path: "/aa"},
+    {path: "/aa/aaa"}
+  ], d => d.path);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      },
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("hierarchify(data, path) accepts an iterable", () => {
+  const root = hierarchify(new Set([
+    {path: "/ab"},
+    {path: "/aa"},
+    {path: "/aa/aaa"}
+  ]), d => d.path);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      },
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("hierarchify(data, path) coerces paths to strings", () => {
+  class Path {
+    constructor(path) {
+      this.path = path;
+    }
+    toString() {
+      return this.path;
+    }
+  }
+  const root = hierarchify([
+    {path: "/ab"},
+    {path: "/aa"},
+    {path: "/aa/aaa"}
+  ], d => new Path(d.path));
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      },
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
+});
+
+function noparent(node) {
+  const copy = {};
+  for (const k in node) {
+    if (node.hasOwnProperty(k)) { // eslint-disable-line no-prototype-builtins
+      switch (k) {
+        case "children": copy.children = node.children.map(noparent); break;
+        case "parent": break;
+        default: copy[k] = node[k]; break;
+      }
+    }
+  }
+  return copy;
+}


### PR DESCRIPTION
This helper for d3.stratify imputes internal nodes using the specified path function, which returns slash-separated ids (as per a typical UNIX-y file system). Fixes #33.

Now that JavaScript has all sorts of niceties for destructuring and optional arguments, I’d also like to start moving away from the D3 “getter-setter” pattern in favor of options objects. For example, instead of:

```js
const root = d3.stratify().id(d => d.id).parentId(d => d.parentId)(data);
```

You’d say:

```js
const root = d3.stratify(data, {id: d => d.id, parentId: d => d.parentId));
```

This allows D3 classes to favor immutability, and makes it easier to share options via the spread operator, too. I’ve done that internally here for d3.stratify, but the new option-based API is not exposed externally. I figure we can explore changing the internal API first, although I’m happy to revert this part if you think it’s too aggressive.

I originally thought about this being a _path_ option for d3.stratify, but it’s a little awkward since if you specify the _path_ option, it’ll ignore the _id_ and _parentId_, so I thought maybe it would be better to separate the two. That said I might try a variant of this PR that is more minimal.