### PR TITLE
stratify.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const tree = d3.treemap();
 
 Before you can compute a hierarchical layout, you need a root node. If your data is already in a hierarchical format, such as JSON, you can pass it directly to [d3.hierarchy](#hierarchy); otherwise, you can rearrange tabular data, such as comma-separated values (CSV), into a hierarchy using [d3.stratify](#stratify).
 
-<a name="hierarchy" href="#hierarchy">#</a> d3.<b>hierarchy</b>(<i>data</i>[, <i>children</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/index.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
+<a name="hierarchy" href="#hierarchy">#</a> d3.<b>hierarchy</b>(<i>data</i>[, <i>children</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/index.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
 
 Constructs a root node from the specified hierarchical *data*. The specified *data* must be an object representing the root node. For example:
 
@@ -106,7 +106,7 @@ function children(d) {
 }
 ```
 
-This allows you to pass the result of [d3.group](https://github.com/d3/d3-array/blob/master/README.md#group) or [d3.rollup](https://github.com/d3/d3-array/blob/master/README.md#rollup) to d3.hierarchy.
+This allows you to pass the result of [d3.group](https://github.com/d3/d3-array/blob/main/README.md#group) or [d3.rollup](https://github.com/d3/d3-array/blob/main/README.md#rollup) to d3.hierarchy.
 
 The returned node and each descendant has the following properties:
 
@@ -119,31 +119,31 @@ The returned node and each descendant has the following properties:
 
 This method can also be used to test if a node is an `instanceof d3.hierarchy` and to extend the node prototype.
 
-<a name="node_ancestors" href="#node_ancestors">#</a> <i>node</i>.<b>ancestors</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/ancestors.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
+<a name="node_ancestors" href="#node_ancestors">#</a> <i>node</i>.<b>ancestors</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/ancestors.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
 
 Returns the array of ancestors nodes, starting with this node, then followed by each parent up to the root.
 
-<a name="node_descendants" href="#node_descendants">#</a> <i>node</i>.<b>descendants</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/descendants.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
+<a name="node_descendants" href="#node_descendants">#</a> <i>node</i>.<b>descendants</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/descendants.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
 
 Returns the array of descendant nodes, starting with this node, then followed by each child in topological order.
 
-<a name="node_leaves" href="#node_leaves">#</a> <i>node</i>.<b>leaves</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/leaves.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
+<a name="node_leaves" href="#node_leaves">#</a> <i>node</i>.<b>leaves</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/leaves.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
 
 Returns the array of leaf nodes in traversal order; leaves are nodes with no children.
 
-<a name="node_find" href="#node_find">#</a> <i>node</i>.<b>find</b>(<i>filter</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/find.js)<!-- , [Examples](https://observablehq.com/@d3/d3-hierarchy) -->
+<a name="node_find" href="#node_find">#</a> <i>node</i>.<b>find</b>(<i>filter</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/find.js)<!-- , [Examples](https://observablehq.com/@d3/d3-hierarchy) -->
 
 Returns the first node in the hierarchy from this *node* for which the specified *filter* returns a truthy value. undefined if no such node is found.
 
-<a name="node_path" href="#node_path">#</a> <i>node</i>.<b>path</b>(<i>target</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/path.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
+<a name="node_path" href="#node_path">#</a> <i>node</i>.<b>path</b>(<i>target</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/path.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
 
 Returns the shortest path through the hierarchy from this *node* to the specified *target* node. The path starts at this *node*, ascends to the least common ancestor of this *node* and the *target* node, and then descends to the *target* node. This is particularly useful for [hierarchical edge bundling](https://observablehq.com/@d3/hierarchical-edge-bundling).
 
-<a name="node_links" href="#node_links">#</a> <i>node</i>.<b>links</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/links.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
+<a name="node_links" href="#node_links">#</a> <i>node</i>.<b>links</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/links.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
 
 Returns an array of links for this *node* and its descendants, where each *link* is an object that defines source and target properties. The source of each link is the parent node, and the target is a child node.
 
-<a name="node_sum" href="#node_sum">#</a> <i>node</i>.<b>sum</b>(<i>value</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/sum.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
+<a name="node_sum" href="#node_sum">#</a> <i>node</i>.<b>sum</b>(<i>value</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/sum.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
 
 Evaluates the specified *value* function for this *node* and each descendant in [post-order traversal](#node_eachAfter), and returns this *node*. The *node*.value property of each node is set to the numeric value returned by the specified function plus the combined value of all children. The function is passed the node’s data, and must return a non-negative number. The *value* accessor is evaluated for *node* and every descendant, including internal nodes; if you only want leaf nodes to have internal value, then return zero for any node with children. [For example](https://observablehq.com/@d3/treemap-by-count), as an alternative to [*node*.count](#node_count):
 
@@ -166,11 +166,11 @@ var nodes = treemap(root
 
 This example assumes that the node data has a value field.
 
-<a name="node_count" href="#node_count">#</a> <i>node</i>.<b>count</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/count.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
+<a name="node_count" href="#node_count">#</a> <i>node</i>.<b>count</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/count.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
 
 Computes the number of leaves under this *node* and assigns it to *node*.value, and similarly for every descendant of *node*. If this *node* is a leaf, its count is one. Returns this *node*. See also [*node*.sum](#node_sum).
 
-<a name="node_sort" href="#node_sort">#</a> <i>node</i>.<b>sort</b>(<i>compare</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/sort.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
+<a name="node_sort" href="#node_sort">#</a> <i>node</i>.<b>sort</b>(<i>compare</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/sort.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
 
 Sorts the children of this *node*, if any, and each of this *node*’s descendants’ children, in [pre-order traversal](#node_eachBefore) using the specified *compare* function, and returns this *node*. The specified function is passed two nodes *a* and *b* to compare. If *a* should be before *b*, the function must return a value less than zero; if *b* should be before *a*, the function must return a value greater than zero; otherwise, the relative order of *a* and *b* are not specified. See [*array*.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) for more.
 
@@ -200,7 +200,7 @@ root
 
 You must call *node*.sort before invoking a hierarchical layout if you want the new sort order to affect the layout; see [*node*.sum](#node_sum) for an example.
 
-<a name="node_iterator" href="#node_iterator">#</a> <i>node</i>\[<b>Symbol.iterator</b>\]() [<>](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/iterator.js "Source")
+<a name="node_iterator" href="#node_iterator">#</a> <i>node</i>\[<b>Symbol.iterator</b>\]() [<>](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/iterator.js "Source")
 
 Returns an iterator over the *node*’s descendants in breadth-first order. For example:
 
@@ -210,19 +210,19 @@ for (const descendant of node) {
 }
 ```
 
-<a name="node_each" href="#node_each">#</a> <i>node</i>.<b>each</b>(<i>function</i>[, <i>that</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/each.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
+<a name="node_each" href="#node_each">#</a> <i>node</i>.<b>each</b>(<i>function</i>[, <i>that</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/each.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
 
 Invokes the specified *function* for *node* and each descendant in [breadth-first order](https://en.wikipedia.org/wiki/Breadth-first_search), such that a given *node* is only visited if all nodes of lesser depth have already been visited, as well as all preceding nodes of the same depth. The specified function is passed the current *descendant*, the zero-based traversal *index*, and this *node*. If *that* is specified, it is the this context of the callback.
 
-<a name="node_eachAfter" href="#node_eachAfter">#</a> <i>node</i>.<b>eachAfter</b>(<i>function</i>[, <i>that</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/eachAfter.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
+<a name="node_eachAfter" href="#node_eachAfter">#</a> <i>node</i>.<b>eachAfter</b>(<i>function</i>[, <i>that</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/eachAfter.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
 
 Invokes the specified *function* for *node* and each descendant in [post-order traversal](https://en.wikipedia.org/wiki/Tree_traversal#Post-order), such that a given *node* is only visited after all of its descendants have already been visited. The specified function is passed the current *descendant*, the zero-based traversal *index*, and this *node*. If *that* is specified, it is the this context of the callback.
 
-<a name="node_eachBefore" href="#node_eachBefore">#</a> <i>node</i>.<b>eachBefore</b>(<i>function</i>[, <i>that</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/eachBefore.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
+<a name="node_eachBefore" href="#node_eachBefore">#</a> <i>node</i>.<b>eachBefore</b>(<i>function</i>[, <i>that</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/eachBefore.js), [Examples](https://observablehq.com/@d3/visiting-a-d3-hierarchy)
 
 Invokes the specified *function* for *node* and each descendant in [pre-order traversal](https://en.wikipedia.org/wiki/Tree_traversal#Pre-order), such that a given *node* is only visited after all of its ancestors have already been visited. The specified function is passed the current *descendant*, the zero-based traversal *index*, and this *node*. If *that* is specified, it is the this context of the callback.
 
-<a name="node_copy" href="#node_copy">#</a> <i>node</i>.<b>copy</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/hierarchy/index.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
+<a name="node_copy" href="#node_copy">#</a> <i>node</i>.<b>copy</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/hierarchy/index.js), [Examples](https://observablehq.com/@d3/d3-hierarchy)
 
 Return a deep copy of the subtree starting at this *node*. (The returned deep copy shares the same data, however.) The returned node is the root of a new tree; the returned node’s parent is always null and its depth is always zero.
 
@@ -290,19 +290,19 @@ var root = d3.stratify()
 
 This returns:
 
-[<img alt="Stratify" src="https://raw.githubusercontent.com/d3/d3-hierarchy/master/img/stratify.png">](https://runkit.com/mbostock/56fed33d8630b01300f72daa)
+[<img alt="Stratify" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/stratify.png">](https://runkit.com/mbostock/56fed33d8630b01300f72daa)
 
 This hierarchy can now be passed to a hierarchical layout, such as [d3.tree](#_tree), for visualization.
 
-<a name="stratify" href="#stratify">#</a> d3.<b>stratify</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
+<a name="stratify" href="#stratify">#</a> d3.<b>stratify</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
 
 Constructs a new stratify operator with the default settings.
 
-<a name="_stratify" href="#_stratify">#</a> <i>stratify</i>(<i>data</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
+<a name="_stratify" href="#_stratify">#</a> <i>stratify</i>(<i>data</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
 
 Generates a new hierarchy from the specified tabular *data*.
 
-<a name="stratify_id" href="#stratify_id">#</a> <i>stratify</i>.<b>id</b>([<i>id</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
+<a name="stratify_id" href="#stratify_id">#</a> <i>stratify</i>.<b>id</b>([<i>id</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
 
 If *id* is specified, sets the id accessor to the given function and returns this stratify operator. Otherwise, returns the current id accessor, which defaults to:
 
@@ -314,7 +314,7 @@ function id(d) {
 
 The id accessor is invoked for each element in the input data passed to the [stratify operator](#_stratify), being passed the current datum (*d*) and the current index (*i*). The returned string is then used to identify the node’s relationships in conjunction with the [parent id](#stratify_parentId). For leaf nodes, the id may be undefined; otherwise, the id must be unique. (Null and the empty string are equivalent to undefined.)
 
-<a name="stratify_parentId" href="#stratify_parentId">#</a> <i>stratify</i>.<b>parentId</b>([<i>parentId</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
+<a name="stratify_parentId" href="#stratify_parentId">#</a> <i>stratify</i>.<b>parentId</b>([<i>parentId</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
 
 If *parentId* is specified, sets the parent id accessor to the given function and returns this stratify operator. Otherwise, returns the current parent id accessor, which defaults to:
 
@@ -326,7 +326,7 @@ function parentId(d) {
 
 The parent id accessor is invoked for each element in the input data passed to the [stratify operator](#_stratify), being passed the current datum (*d*) and the current index (*i*). The returned string is then used to identify the node’s relationships in conjunction with the [id](#stratify_id). For the root node, the parent id should be undefined. (Null and the empty string are equivalent to undefined.) There must be exactly one root node in the input data, and no circular relationships.
 
-<a name="stratify_path" href="#stratify_path">#</a> <i>stratify</i>.<b>path</b>([<i>path</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
+<a name="stratify_path" href="#stratify_path">#</a> <i>stratify</i>.<b>path</b>([<i>path</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
 
 If *path* is specified, sets the path accessor to the given function and returns this stratify operator. Otherwise, returns the current path accessor, which defaults to undefined. If a path accessor is set, the id and parentId arguments are ignored, and a unix-like hierarchy is computed on the slash-delimited strings returned by the path accessor, imputing parent nodes and ids as necessary.
 
@@ -336,11 +336,11 @@ d3.stratify().path(d => d)(["a/b", "a/c"]); // nodes with id "/a", "/a/b", "/a/c
 
 ### Cluster
 
-[<img alt="Dendrogram" src="https://raw.githubusercontent.com/d3/d3-hierarchy/master/img/cluster.png">](https://observablehq.com/@d3/cluster-dendrogram)
+[<img alt="Dendrogram" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/cluster.png">](https://observablehq.com/@d3/cluster-dendrogram)
 
 The **cluster layout** produces [dendrograms](http://en.wikipedia.org/wiki/Dendrogram): node-link diagrams that place leaf nodes of the tree at the same depth. Dendrograms are typically less compact than [tidy trees](#tree), but are useful when all the leaves should be at the same level, such as for hierarchical clustering or [phylogenetic tree diagrams](https://observablehq.com/@mbostock/tree-of-life).
 
-<a name="cluster" href="#cluster">#</a> d3.<b>cluster</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/cluster.js), [Examples](https://observablehq.com/@d3/cluster-dendrogram)
+<a name="cluster" href="#cluster">#</a> d3.<b>cluster</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/cluster.js), [Examples](https://observablehq.com/@d3/cluster-dendrogram)
 
 Creates a new cluster layout with default settings.
 
@@ -375,11 +375,11 @@ The separation accessor is used to separate neighboring leaves. The separation f
 
 ### Tree
 
-[<img alt="Tidy Tree" src="https://raw.githubusercontent.com/d3/d3-hierarchy/master/img/tree.png">](https://observablehq.com/@d3/tidy-tree)
+[<img alt="Tidy Tree" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/tree.png">](https://observablehq.com/@d3/tidy-tree)
 
 The **tree** layout produces tidy node-link diagrams of trees using the [Reingold–Tilford “tidy” algorithm](http://reingold.co/tidier-drawings.pdf), improved to run in linear time by [Buchheim *et al.*](http://dirk.jivas.de/papers/buchheim02improving.pdf) Tidy trees are typically more compact than [dendrograms](#cluster).
 
-<a name="tree" href="#tree">#</a> d3.<b>tree</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/tree.js), [Examples](https://observablehq.com/@d3/tidy-tree)
+<a name="tree" href="#tree">#</a> d3.<b>tree</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/tree.js), [Examples](https://observablehq.com/@d3/tidy-tree)
 
 Creates a new tree layout with default settings.
 
@@ -422,11 +422,11 @@ The separation accessor is used to separate neighboring nodes. The separation fu
 
 ### Treemap
 
-[<img alt="Treemap" src="https://raw.githubusercontent.com/d3/d3-hierarchy/master/img/treemap.png">](https://observablehq.com/@d3/treemap)
+[<img alt="Treemap" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/treemap.png">](https://observablehq.com/@d3/treemap)
 
 Introduced by [Ben Shneiderman](http://www.cs.umd.edu/hcil/treemap-history/) in 1991, a **treemap** recursively subdivides area into rectangles according to each node’s associated value. D3’s treemap implementation supports an extensible [tiling method](#treemap_tile): the default [squarified](#treemapSquarify) method seeks to generate rectangles with a [golden](https://en.wikipedia.org/wiki/Golden_ratio) aspect ratio; this offers better readability and size estimation than [slice-and-dice](#treemapSliceDice), which simply alternates between horizontal and vertical subdivision by depth.
 
-<a name="treemap" href="#treemap">#</a> d3.<b>treemap</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/treemap/index.js), [Examples](https://observablehq.com/@d3/treemap)
+<a name="treemap" href="#treemap">#</a> d3.<b>treemap</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/treemap/index.js), [Examples](https://observablehq.com/@d3/treemap)
 
 Creates a new treemap layout with default settings.
 
@@ -485,41 +485,41 @@ If *padding* is specified, sets the left padding to the specified number or func
 
 Several built-in tiling methods are provided for use with [*treemap*.tile](#treemap_tile).
 
-<a name="treemapBinary" href="#treemapBinary">#</a> d3.<b>treemapBinary</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/treemap/binary.js), [Examples](https://observablehq.com/@d3/treemap)
+<a name="treemapBinary" href="#treemapBinary">#</a> d3.<b>treemapBinary</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/treemap/binary.js), [Examples](https://observablehq.com/@d3/treemap)
 
 Recursively partitions the specified *nodes* into an approximately-balanced binary tree, choosing horizontal partitioning for wide rectangles and vertical partitioning for tall rectangles.
 
-<a name="treemapDice" href="#treemapDice">#</a> d3.<b>treemapDice</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/treemap/dice.js), [Examples](https://observablehq.com/@d3/treemap)
+<a name="treemapDice" href="#treemapDice">#</a> d3.<b>treemapDice</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/treemap/dice.js), [Examples](https://observablehq.com/@d3/treemap)
 
 Divides the rectangular area specified by *x0*, *y0*, *x1*, *y1* horizontally according the value of each of the specified *node*’s children. The children are positioned in order, starting with the left edge (*x0*) of the given rectangle. If the sum of the children’s values is less than the specified *node*’s value (*i.e.*, if the specified *node* has a non-zero internal value), the remaining empty space will be positioned on the right edge (*x1*) of the given rectangle.
 
-<a name="treemapSlice" href="#treemapSlice">#</a> d3.<b>treemapSlice</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/treemap/slice.js), [Examples](https://observablehq.com/@d3/treemap)
+<a name="treemapSlice" href="#treemapSlice">#</a> d3.<b>treemapSlice</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/treemap/slice.js), [Examples](https://observablehq.com/@d3/treemap)
 
 Divides the rectangular area specified by *x0*, *y0*, *x1*, *y1* vertically according the value of each of the specified *node*’s children. The children are positioned in order, starting with the top edge (*y0*) of the given rectangle. If the sum of the children’s values is less than the specified *node*’s value (*i.e.*, if the specified *node* has a non-zero internal value), the remaining empty space will be positioned on the bottom edge (*y1*) of the given rectangle.
 
-<a name="treemapSliceDice" href="#treemapSliceDice">#</a> d3.<b>treemapSliceDice</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/treemap/sliceDice.js), [Examples](https://observablehq.com/@d3/treemap)
+<a name="treemapSliceDice" href="#treemapSliceDice">#</a> d3.<b>treemapSliceDice</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/treemap/sliceDice.js), [Examples](https://observablehq.com/@d3/treemap)
 
 If the specified *node* has odd depth, delegates to [treemapSlice](#treemapSlice); otherwise delegates to [treemapDice](#treemapDice).
 
-<a name="treemapSquarify" href="#treemapSquarify">#</a> d3.<b>treemapSquarify</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/treemap/squarify.js), [Examples](https://observablehq.com/@d3/treemap)
+<a name="treemapSquarify" href="#treemapSquarify">#</a> d3.<b>treemapSquarify</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/treemap/squarify.js), [Examples](https://observablehq.com/@d3/treemap)
 
 Implements the [squarified treemap](https://www.win.tue.nl/~vanwijk/stm.pdf) algorithm by Bruls *et al.*, which seeks to produce rectangles of a given [aspect ratio](#squarify_ratio).
 
-<a name="treemapResquarify" href="#treemapResquarify">#</a> d3.<b>treemapResquarify</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/treemap/resquarify.js), [Examples](https://observablehq.com/@d3/animated-treemap)
+<a name="treemapResquarify" href="#treemapResquarify">#</a> d3.<b>treemapResquarify</b>(<i>node</i>, <i>x0</i>, <i>y0</i>, <i>x1</i>, <i>y1</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/treemap/resquarify.js), [Examples](https://observablehq.com/@d3/animated-treemap)
 
 Like [d3.treemapSquarify](#treemapSquarify), except preserves the topology (node adjacencies) of the previous layout computed by d3.treemapResquarify, if there is one and it used the same [target aspect ratio](#squarify_ratio). This tiling method is good for animating changes to treemaps because it only changes node sizes and not their relative positions, thus avoiding distracting shuffling and occlusion. The downside of a stable update, however, is a suboptimal layout for subsequent updates: only the first layout uses the Bruls *et al.* squarified algorithm.
 
-<a name="squarify_ratio" href="#squarify_ratio">#</a> <i>squarify</i>.<b>ratio</b>(<i>ratio</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/treemap/squarify.js), [Examples](https://observablehq.com/@d3/treemap)
+<a name="squarify_ratio" href="#squarify_ratio">#</a> <i>squarify</i>.<b>ratio</b>(<i>ratio</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/treemap/squarify.js), [Examples](https://observablehq.com/@d3/treemap)
 
 Specifies the desired aspect ratio of the generated rectangles. The *ratio* must be specified as a number greater than or equal to one. Note that the orientation of the generated rectangles (tall or wide) is not implied by the ratio; for example, a ratio of two will attempt to produce a mixture of rectangles whose *width*:*height* ratio is either 2:1 or 1:2. (However, you can approximately achieve this result by generating a square treemap at different dimensions, and then [stretching the treemap](https://observablehq.com/@d3/stretched-treemap) to the desired aspect ratio.) Furthermore, the specified *ratio* is merely a hint to the tiling algorithm; the rectangles are not guaranteed to have the specified aspect ratio. If not specified, the aspect ratio defaults to the golden ratio, φ = (1 + sqrt(5)) / 2, per [Kong *et al.*](http://vis.stanford.edu/papers/perception-treemaps)
 
 ### Partition
 
-[<img alt="Partition" src="https://raw.githubusercontent.com/d3/d3-hierarchy/master/img/partition.png">](https://observablehq.com/@d3/icicle)
+[<img alt="Partition" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/partition.png">](https://observablehq.com/@d3/icicle)
 
 The **partition layout** produces adjacency diagrams: a space-filling variant of a node-link tree diagram. Rather than drawing a link between parent and child in the hierarchy, nodes are drawn as solid areas (either arcs or rectangles), and their placement relative to other nodes reveals their position in the hierarchy. The size of the nodes encodes a quantitative dimension that would be difficult to show in a node-link diagram.
 
-<a name="partition" href="#partition">#</a> d3.<b>partition</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/partition.js), [Examples](https://observablehq.com/@d3/icicle)
+<a name="partition" href="#partition">#</a> d3.<b>partition</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/partition.js), [Examples](https://observablehq.com/@d3/icicle)
 
 Creates a new partition layout with the default settings.
 
@@ -548,11 +548,11 @@ If *padding* is specified, sets the padding to the specified number and returns 
 
 ### Pack
 
-[<img alt="Circle-Packing" src="https://raw.githubusercontent.com/d3/d3-hierarchy/master/img/pack.png">](https://observablehq.com/@d3/circle-packing)
+[<img alt="Circle-Packing" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/pack.png">](https://observablehq.com/@d3/circle-packing)
 
 Enclosure diagrams use containment (nesting) to represent a hierarchy. The size of the leaf circles encodes a quantitative dimension of the data. The enclosing circles show the approximate cumulative size of each subtree, but due to wasted space there is some distortion; only the leaf nodes can be compared accurately. Although [circle packing](http://en.wikipedia.org/wiki/Circle_packing) does not use space as efficiently as a [treemap](#treemap), the “wasted” space more prominently reveals the hierarchical structure.
 
-<a name="pack" href="#pack">#</a> d3.<b>pack</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/pack/index.js), [Examples](https://observablehq.com/@d3/circle-packing)
+<a name="pack" href="#pack">#</a> d3.<b>pack</b>() · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/pack/index.js), [Examples](https://observablehq.com/@d3/circle-packing)
 
 Creates a new pack layout with the default settings.
 
@@ -578,7 +578,7 @@ If *size* is specified, sets this pack layout’s size to the specified two-elem
 
 If *padding* is specified, sets this pack layout’s padding accessor to the specified number or function and returns this pack layout. If *padding* is not specified, returns the current padding accessor, which defaults to the constant zero. When siblings are packed, tangent siblings will be separated by approximately the specified padding; the enclosing parent circle will also be separated from its children by approximately the specified padding. If an [explicit radius](#pack_radius) is not specified, the padding is approximate because a two-pass algorithm is needed to fit within the [layout size](#pack_size): the circles are first packed without padding; a scaling factor is computed and applied to the specified padding; and lastly the circles are re-packed with padding.
 
-<a name="packSiblings" href="#packSiblings">#</a> d3.<b>packSiblings</b>(<i>circles</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/pack/siblings.js)
+<a name="packSiblings" href="#packSiblings">#</a> d3.<b>packSiblings</b>(<i>circles</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/pack/siblings.js)
 
 Packs the specified array of *circles*, each of which must have a *circle*.r property specifying the circle’s radius. Assigns the following properties to each circle:
 
@@ -587,6 +587,6 @@ Packs the specified array of *circles*, each of which must have a *circle*.r pro
 
 The circles are positioned according to the front-chain packing algorithm by [Wang *et al.*](https://dl.acm.org/citation.cfm?id=1124851)
 
-<a name="packEnclose" href="#packEnclose">#</a> d3.<b>packEnclose</b>(<i>circles</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/pack/enclose.js), [Examples](https://observablehq.com/@d3/d3-packenclose)
+<a name="packEnclose" href="#packEnclose">#</a> d3.<b>packEnclose</b>(<i>circles</i>) · [Source](https://github.com/d3/d3-hierarchy/blob/main/src/pack/enclose.js), [Examples](https://observablehq.com/@d3/d3-packenclose)
 
 Computes the [smallest circle](https://en.wikipedia.org/wiki/Smallest-circle_problem) that encloses the specified array of *circles*, each of which must have a *circle*.r property specifying the circle’s radius, and *circle*.x and *circle*.y properties specifying the circle’s center. The enclosing circle is computed using the [Matoušek-Sharir-Welzl algorithm](http://www.inf.ethz.ch/personal/emo/PublFiles/SubexLinProg_ALG16_96.pdf). (See also [Apollonius’ Problem](https://bl.ocks.org/mbostock/751fdd637f4bc2e3f08b).)

--- a/README.md
+++ b/README.md
@@ -326,6 +326,14 @@ function parentId(d) {
 
 The parent id accessor is invoked for each element in the input data passed to the [stratify operator](#_stratify), being passed the current datum (*d*) and the current index (*i*). The returned string is then used to identify the node’s relationships in conjunction with the [id](#stratify_id). For the root node, the parent id should be undefined. (Null and the empty string are equivalent to undefined.) There must be exactly one root node in the input data, and no circular relationships.
 
+<a name="stratify_path" href="#stratify_path">#</a> <i>stratify</i>.<b>path</b>([<i>path</i>]) · [Source](https://github.com/d3/d3-hierarchy/blob/master/src/stratify.js), [Examples](https://observablehq.com/@d3/d3-stratify)
+
+If *path* is specified, sets the path accessor to the given function and returns this stratify operator. Otherwise, returns the current path accessor, which defaults to undefined. If a path accessor is set, the id and parentId arguments are ignored, and a unix-like hierarchy is computed on the slash-delimited strings returned by the path accessor, imputing parent nodes and ids as necessary.
+
+```js
+d3.stratify().path(d => d)(["a/b", "a/c"]); // nodes with id "/a", "/a/b", "/a/c"
+```
+
 ### Cluster
 
 [<img alt="Dendrogram" src="https://raw.githubusercontent.com/d3/d3-hierarchy/master/img/cluster.png">](https://observablehq.com/@d3/cluster-dendrogram)

--- a/src/stratify.js
+++ b/src/stratify.js
@@ -2,7 +2,8 @@ import {optional} from "./accessors.js";
 import {Node, computeHeight} from "./hierarchy/index.js";
 
 var preroot = {depth: -1},
-    ambiguous = {};
+    ambiguous = {},
+    imputed = {};
 
 function defaultId(d) {
   return d.id;
@@ -40,7 +41,7 @@ export default function() {
           S.add(i);
           I.push(i);
           P.push(parentof(i));
-          nodes.push(null);
+          nodes.push(imputed);
         }
       }
       currentId = (_, i) => I[i];
@@ -74,6 +75,20 @@ export default function() {
     }
 
     if (!root) throw new Error("no root");
+
+    // When imputing internal nodes, only introduce roots if needed.
+    // Then replace the imputed marker data with null.
+    if (path != null) {
+      while (root.data === imputed && root.children.length === 1) {
+        root = root.children[0], --n;
+      }
+      for (let i = nodes.length - 1; i >= 0; --i) {
+        node = nodes[i];
+        if (node.data !== imputed) break;
+        node.data = null;
+      }
+    }
+
     root.parent = preroot;
     root.eachBefore(function(node) { node.depth = node.parent.depth + 1; --n; }).eachBefore(computeHeight);
     root.parent = null;

--- a/src/stratify.js
+++ b/src/stratify.js
@@ -40,7 +40,7 @@ export default function() {
           S.add(i);
           I.push(i);
           P.push(parentof(i));
-          nodes.push({path: i});
+          nodes.push(null);
         }
       }
       currentId = (_, i) => I[i];

--- a/src/stratify.js
+++ b/src/stratify.js
@@ -34,9 +34,9 @@ export default function() {
     if (path != null) {
       const I = nodes.map((d, i) => normalize(path(d, i, data)));
       const P = I.map(parentof);
-      const S = new Set(I);
+      const S = new Set(I).add("");
       for (const i of P) {
-        if (!S.has(i) && i) {
+        if (!S.has(i)) {
           S.add(i);
           I.push(i);
           P.push(parentof(i));

--- a/test/stratify-test.js
+++ b/test/stratify-test.js
@@ -464,6 +464,42 @@ it("stratify.path(path) returns the root node", () => {
   });
 });
 
+it("stratify.path(path) allows slashes to be escaped", () => {
+  const root = stratify().path(d => d.path)([
+    {path: "/"},
+    {path: "/aa"},
+    {path: "\\/ab"},
+    {path: "/aa\\/aaa"}
+  ]);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 1,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 0,
+        data: {path: "/aa"}
+      },
+      {
+        id: "/\\/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "\\/ab"}
+      },
+      {
+        id: "/aa\\/aaa",
+        depth: 1,
+        height: 0,
+        data: {path: "/aa\\/aaa"}
+      }
+    ]
+  });
+});
+
 it("stratify.path(path) imputes internal nodes", () => {
   const root = stratify().path(d => d.path)([
     {path: "/aa/aaa"},

--- a/test/stratify-test.js
+++ b/test/stratify-test.js
@@ -377,7 +377,7 @@ it("stratify.id(id) observes the specified id function", () => {
 it("stratify.id(id) tests that id is a function", () => {
   const s = stratify();
   assert.throws(() => void s.id(42));
-  assert.throws(() => void s.id(null));
+  assert.throws(() => void s.id("nope"));
 });
 
 it("stratify.parentId(id) observes the specified parent id function", () => {
@@ -423,7 +423,396 @@ it("stratify.parentId(id) observes the specified parent id function", () => {
 it("stratify.parentId(id) tests that id is a function", () => {
   const s = stratify();
   assert.throws(() => void s.parentId(42));
-  assert.throws(() => void s.parentId(null));
+  assert.throws(() => void s.parentId("nope"));
+});
+
+it("stratify.path(path) returns the root node", () => {
+  const root = stratify().path(d => d.path)([
+    {path: "/"},
+    {path: "/aa"},
+    {path: "/ab"},
+    {path: "/aa/aaa"}
+  ]);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      },
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      }
+    ]
+  });
+});
+
+it("stratify.path(path) imputes internal nodes", () => {
+  const root = stratify().path(d => d.path)([
+    {path: "/aa/aaa"},
+    {path: "/ab"}
+  ]);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      },
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("stratify.path(path) allows duplicate leaf paths", () => {
+  const root = stratify().path(d => d.path)([
+    {path: "/aa/aaa"},
+    {path: "/aa/aaa"},
+  ]);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          },
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("stratify.path(path) does not allow duplicate internal paths", () => {
+  assert.throws(() => {
+    stratify().path(d => d.path)([
+      {path: "/aa"},
+      {path: "/aa"},
+      {path: "/aa/aaa"},
+      {path: "/aa/aaa"},
+    ]);
+  }, /ambiguous/);
+});
+
+it("stratify.path(path) implicitly adds leading slashes", () => {
+  const root = stratify().path(d => d.path)([
+    {path: ""},
+    {path: "aa"},
+    {path: "ab"},
+    {path: "aa/aaa"}
+  ]);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: ""},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "aa/aaa"}
+          }
+        ]
+      },
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "ab"}
+      }
+    ]
+  });
+});
+
+it("stratify.path(path) implicitly trims trailing slashes", () => {
+  const root = stratify().path(d => d.path)([
+    {path: "/aa/"},
+    {path: "/ab/"},
+    {path: "/aa/aaa/"}
+  ]);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa/"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa/"}
+          }
+        ]
+      },
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab/"}
+      }
+    ]
+  });
+});
+
+it("stratify.path(path) trims at most one trailing slash", () => {
+  const root = stratify().path(d => d.path)([
+    {path: "/aa///"}
+  ]);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 3,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 2,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/",
+            depth: 2,
+            height: 1,
+            data: {path: "/aa/"},
+            children: [
+              {
+                id: "/aa//",
+                depth: 3,
+                height: 0,
+                data: {path: "/aa///"},
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("stratify.path(path) does not require the data to be in topological order", () => {
+  const root = stratify().path(d => d.path)([
+    {path: "/aa/aaa"},
+    {path: "/aa"},
+    {path: "/ab"}
+  ]);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      },
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      }
+    ]
+  });
+});
+
+it("stratify.path(path) preserves the input order of siblings", () => {
+  const root = stratify().path(d => d.path)([
+    {path: "/ab"},
+    {path: "/aa"},
+    {path: "/aa/aaa"}
+  ]);
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      },
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("stratify.path(path) accepts an iterable", () => {
+  const root = stratify().path(d => d.path)(new Set([
+    {path: "/ab"},
+    {path: "/aa"},
+    {path: "/aa/aaa"}
+  ]));
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      },
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
+});
+
+it("stratify.path(path) coerces paths to strings", () => {
+  class Path {
+    constructor(path) {
+      this.path = path;
+    }
+    toString() {
+      return this.path;
+    }
+  }
+  const root = stratify().path(d => d.path)([
+    {path: "/ab"},
+    {path: "/aa"},
+    {path: "/aa/aaa"}
+  ], d => new Path(d.path));
+  assert(root instanceof hierarchy);
+  assert.deepStrictEqual(noparent(root), {
+    id: "/",
+    depth: 0,
+    height: 2,
+    data: {path: "/"},
+    children: [
+      {
+        id: "/ab",
+        depth: 1,
+        height: 0,
+        data: {path: "/ab"}
+      },
+      {
+        id: "/aa",
+        depth: 1,
+        height: 1,
+        data: {path: "/aa"},
+        children: [
+          {
+            id: "/aa/aaa",
+            depth: 2,
+            height: 0,
+            data: {path: "/aa/aaa"}
+          }
+        ]
+      }
+    ]
+  });
 });
 
 function noparent(node) {

--- a/test/stratify-test.js
+++ b/test/stratify-test.js
@@ -507,30 +507,22 @@ it("stratify.path(path) allows duplicate leaf paths", () => {
   ]);
   assert(root instanceof hierarchy);
   assert.deepStrictEqual(noparent(root), {
-    id: "/",
+    id: "/aa",
     depth: 0,
-    height: 2,
+    height: 1,
     data: null,
     children: [
       {
-        id: "/aa",
+        id: "/aa/aaa",
         depth: 1,
-        height: 1,
-        data: null,
-        children: [
-          {
-            id: "/aa/aaa",
-            depth: 2,
-            height: 0,
-            data: {path: "/aa/aaa", number: 1}
-          },
-          {
-            id: "/aa/aaa",
-            depth: 2,
-            height: 0,
-            data: {path: "/aa/aaa", number: 2}
-          }
-        ]
+        height: 0,
+        data: {path: "/aa/aaa", number: 1}
+      },
+      {
+        id: "/aa/aaa",
+        depth: 1,
+        height: 0,
+        data: {path: "/aa/aaa", number: 2}
       }
     ]
   });
@@ -624,7 +616,8 @@ it("stratify.path(path) implicitly trims trailing slashes", () => {
 
 it("stratify.path(path) trims at most one trailing slash", () => {
   const root = stratify().path(d => d.path)([
-    {path: "/aa///"}
+    {path: "/aa///"},
+    {path: "/b"}
   ]);
   assert(root instanceof hierarchy);
   assert.deepStrictEqual(noparent(root), {
@@ -633,6 +626,12 @@ it("stratify.path(path) trims at most one trailing slash", () => {
     height: 3,
     data: null,
     children: [
+      {
+        id: "/b",
+        depth: 1,
+        height: 0,
+        data: {path: "/b"}
+      },
       {
         id: "/aa",
         depth: 1,

--- a/test/stratify-test.js
+++ b/test/stratify-test.js
@@ -474,7 +474,7 @@ it("stratify.path(path) imputes internal nodes", () => {
     id: "/",
     depth: 0,
     height: 2,
-    data: {path: "/"},
+    data: null,
     children: [
       {
         id: "/ab",
@@ -486,7 +486,7 @@ it("stratify.path(path) imputes internal nodes", () => {
         id: "/aa",
         depth: 1,
         height: 1,
-        data: {path: "/aa"},
+        data: null,
         children: [
           {
             id: "/aa/aaa",
@@ -502,33 +502,33 @@ it("stratify.path(path) imputes internal nodes", () => {
 
 it("stratify.path(path) allows duplicate leaf paths", () => {
   const root = stratify().path(d => d.path)([
-    {path: "/aa/aaa"},
-    {path: "/aa/aaa"},
+    {path: "/aa/aaa", number: 1},
+    {path: "/aa/aaa", number: 2},
   ]);
   assert(root instanceof hierarchy);
   assert.deepStrictEqual(noparent(root), {
     id: "/",
     depth: 0,
     height: 2,
-    data: {path: "/"},
+    data: null,
     children: [
       {
         id: "/aa",
         depth: 1,
         height: 1,
-        data: {path: "/aa"},
+        data: null,
         children: [
           {
             id: "/aa/aaa",
             depth: 2,
             height: 0,
-            data: {path: "/aa/aaa"}
+            data: {path: "/aa/aaa", number: 1}
           },
           {
             id: "/aa/aaa",
             depth: 2,
             height: 0,
-            data: {path: "/aa/aaa"}
+            data: {path: "/aa/aaa", number: 2}
           }
         ]
       }
@@ -596,7 +596,7 @@ it("stratify.path(path) implicitly trims trailing slashes", () => {
     id: "/",
     depth: 0,
     height: 2,
-    data: {path: "/"},
+    data: null,
     children: [
       {
         id: "/aa",
@@ -631,19 +631,19 @@ it("stratify.path(path) trims at most one trailing slash", () => {
     id: "/",
     depth: 0,
     height: 3,
-    data: {path: "/"},
+    data: null,
     children: [
       {
         id: "/aa",
         depth: 1,
         height: 2,
-        data: {path: "/aa"},
+        data: null,
         children: [
           {
             id: "/aa/",
             depth: 2,
             height: 1,
-            data: {path: "/aa/"},
+            data: null,
             children: [
               {
                 id: "/aa//",
@@ -670,7 +670,7 @@ it("stratify.path(path) does not require the data to be in topological order", (
     id: "/",
     depth: 0,
     height: 2,
-    data: {path: "/"},
+    data: null,
     children: [
       {
         id: "/aa",
@@ -707,7 +707,7 @@ it("stratify.path(path) preserves the input order of siblings", () => {
     id: "/",
     depth: 0,
     height: 2,
-    data: {path: "/"},
+    data: null,
     children: [
       {
         id: "/ab",
@@ -744,7 +744,7 @@ it("stratify.path(path) accepts an iterable", () => {
     id: "/",
     depth: 0,
     height: 2,
-    data: {path: "/"},
+    data: null,
     children: [
       {
         id: "/ab",
@@ -789,7 +789,7 @@ it("stratify.path(path) coerces paths to strings", () => {
     id: "/",
     depth: 0,
     height: 2,
-    data: {path: "/"},
+    data: null,
     children: [
       {
         id: "/ab",


### PR DESCRIPTION
This new d3.stratify feature imputes internal nodes using the specified path function, which returns slash-separated ids (as per a typical UNIX-y file system). Alternative to #184. Fixes #33.