### PR TITLE
WIP Adopt fat arrow syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,8 +283,8 @@ To convert to a hierarchy:
 
 ```js
 var root = d3.stratify()
-    .id(function(d) { return d.name; })
-    .parentId(function(d) { return d.parent; })
+    .id((d) => d.name)
+    .parentId((d) => d.parent)
     (table);
 ```
 


### PR DESCRIPTION
As I use this documentation, I find myself migrating to fat arrow syntax. This PR is a start at migrating the sample code to use this syntax.