### PR TITLE
Improvement to default iterator generator function used in 

### DIFF
--- a/src/hierarchy/iterator.js
+++ b/src/hierarchy/iterator.js
@@ -1,12 +1,12 @@
 export default function*() {
-  var node = this, current, next = [node], children, i, n;
+  let node = this, current, next = [node], children;
   do {
-    current = next.reverse(), next = [];
+    current = next, next = [];
     while (node = current.pop()) {
       yield node;
       if (children = node.children) {
-        for (i = 0, n = children.length; i < n; ++i) {
-          next.push(children[i]);
+        for (let i = 0; i < children.length; ++i) {
+          next.unshift(children[i]);
         }
       }
     }


### PR DESCRIPTION
There's no need to call reverse() on the "next" array if you insert elements into the array in reverse order via unshift() (in the inner for loop) instead of push() (how it was being done originally).